### PR TITLE
Switch from $ to underscores as separators in names

### DIFF
--- a/src/main/kotlin/org/treeWare/mySql/operator/GenerateCreateDatabaseCommands.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/GenerateCreateDatabaseCommands.kt
@@ -64,7 +64,7 @@ private class ForeignKey(
 
     override fun getColumns(): List<Column> =
         if (localKeyPrefix == null) keys
-        else keys.map { Column("$localKeyPrefix\$${it.name}", it.type) }
+        else keys.map { Column("${localKeyPrefix}__${it.name}", it.type) }
 
     override fun writeColumnsTo(writer: Writer) {
         keys.forEach { writeColumnTo(writer, it.name, it.type, localKeyPrefix) }
@@ -92,7 +92,7 @@ private class ForeignKey(
             if (index != 0) writer.write(", ")
             localKeyPrefix?.also {
                 writer.write(it)
-                writer.write("$")
+                writer.write("__")
             }
             writer.write(column.name)
         }
@@ -103,7 +103,7 @@ private class ForeignKey(
             if (index != 0) writer.write(", ")
             foreignKeyPrefix?.also {
                 writer.write(it)
-                writer.write("$")
+                writer.write("__")
             }
             writer.write(column.name)
         }
@@ -116,7 +116,7 @@ private fun writeColumnTo(writer: Writer, name: String, type: String, namePrefix
     writer.write(",\n  ")
     namePrefix?.also {
         writer.write(namePrefix)
-        writer.write("$")
+        writer.write("__")
     }
     writer.write(name)
     writer.write(" ")

--- a/src/main/kotlin/org/treeWare/mySql/operator/InternalColumns.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/InternalColumns.kt
@@ -1,9 +1,9 @@
 package org.treeWare.mySql.operator
 
-const val CREATED_ON_COLUMN_NAME = "created_on$"
-const val UPDATED_ON_COLUMN_NAME = "updated_on$"
-const val FIELD_PATH_COLUMN_NAME = "field_path$"
+const val CREATED_ON_COLUMN_NAME = "created_on_"
+const val UPDATED_ON_COLUMN_NAME = "updated_on_"
+const val FIELD_PATH_COLUMN_NAME = "field_path_"
 
-const val SINGLETON_KEY_COLUMN_NAME = "singleton_key$"
+const val SINGLETON_KEY_COLUMN_NAME = "singleton_key_"
 const val SINGLETON_KEY_COLUMN_TYPE = "INT UNSIGNED"
 const val SINGLETON_KEY_COLUMN_VALUE = 0

--- a/src/main/kotlin/org/treeWare/mySql/operator/delegate/SqlColumn.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/delegate/SqlColumn.kt
@@ -228,7 +228,7 @@ internal fun addSqlColumn(column: SqlColumn, nameValueSeparator: String, builder
 }
 
 internal fun addSqlColumnName(column: SqlColumn, builder: StringBuilder) {
-    column.namePrefix?.also { builder.append(it).append("$") }
+    column.namePrefix?.also { builder.append(it).append("__") }
     builder.append(column.name)
 }
 

--- a/src/main/kotlin/org/treeWare/mySql/operator/delegate/geoPoint/GeoPointGetEntityDelegate.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/delegate/geoPoint/GeoPointGetEntityDelegate.kt
@@ -13,8 +13,8 @@ internal class GeoPointGetEntityDelegate : GetEntityDelegate, MySqlGetEntityDele
     override fun getSelectColumns(fieldMeta: EntityModel): List<SqlColumn> {
         val columnName = getMetaName(fieldMeta)
         return listOf(
-            SqlColumn(null, "ST_Longitude($columnName) AS $columnName\$lng", null),
-            SqlColumn(null, "ST_Latitude($columnName) AS $columnName\$lat", null),
+            SqlColumn(null, "ST_Longitude($columnName) AS ${columnName}__lng", null),
+            SqlColumn(null, "ST_Latitude($columnName) AS ${columnName}__lat", null),
         )
     }
 

--- a/src/main/kotlin/org/treeWare/mySql/validation/ValidateMySqlMetaModelMap.kt
+++ b/src/main/kotlin/org/treeWare/mySql/validation/ValidateMySqlMetaModelMap.kt
@@ -64,7 +64,7 @@ private class ValidateMySqlMetaModelMapVisitor(
     override fun visitMainMeta(leaderMainMeta1: MutableMainModel): TraversalAction {
         val mainMetaName = getMainMetaName(leaderMainMeta1)
         path.addLast(mainMetaName)
-        databaseName = "${environment}\$$mainMetaName"
+        databaseName = "${environment}__$mainMetaName"
         val nameErrors = validateDatabaseName(databaseName)
         if (nameErrors.isNotEmpty()) errors.addAll(nameErrors)
         else {
@@ -95,7 +95,7 @@ private class ValidateMySqlMetaModelMapVisitor(
         path.addLast(entityName)
         val aux = getMySqlMetaModelMap(leaderEntityMeta1) ?: return TraversalAction.ABORT_SUB_TREE
         val tableSuffix = aux.tableName ?: entityName
-        val tableName = "${tablePrefix}\$${tableSuffix}"
+        val tableName = "${tablePrefix}__${tableSuffix}"
         val entityErrors = mutableListOf<String>()
         entityErrors.addAll(validateTableName(tableName))
         entityErrors.addAll(validateKeys(getPathName(), leaderEntityMeta1))

--- a/src/test/kotlin/org/treeWare/mySql/operator/CreateDatabaseTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/CreateDatabaseTests.kt
@@ -14,7 +14,7 @@ import org.treeWare.mySql.test.getIndexesSchema
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CreateDatabaseTests {
@@ -28,7 +28,7 @@ class CreateDatabaseTests {
 
     @Test
     fun `Database and tables must be created for the specified meta-model`() {
-        val expectedDatabaseName = "test\$address_book"
+        val expectedDatabaseName = "test__address_book"
 
         val columnsSchemaBefore = getColumnsSchema(dataSource, expectedDatabaseName)
         assertEquals("= Table tables =\n", columnsSchemaBefore)

--- a/src/test/kotlin/org/treeWare/mySql/operator/GetTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/GetTests.kt
@@ -23,7 +23,7 @@ import java.time.ZoneOffset
 import javax.sql.DataSource
 import kotlin.test.assertTrue
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetCreateTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetCreateTests.kt
@@ -25,7 +25,7 @@ import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 
@@ -126,12 +126,12 @@ class SetCreateTests {
         val actualResponse = set(create, setEntityDelegates, dataSource, clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
-            |= Table city${'$'}city_info =
+            |= Table city__city_info =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book/city_info
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book/city_info
             |name: Princeton
             |state: New Jersey
             |country: United States of America
@@ -141,16 +141,16 @@ class SetCreateTests {
             |city_center: null
             |related_city_info: []
             |self: {"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}
-            |self${'$'}name: Princeton
-            |self${'$'}state: New Jersey
-            |self${'$'}country: United States of America
+            |self__name: Princeton
+            |self__state: New Jersey
+            |self__country: United States of America
             |self2: {"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}
-            |self2${'$'}name: Princeton
-            |self2${'$'}state: New Jersey
-            |self2${'$'}country: United States of America
+            |self2__name: Princeton
+            |self2__state: New Jersey
+            |self2__country: United States of America
             |
         """.trimMargin()
-        val actualRows = getTableRows(dataSource, TEST_DATABASE, "city\$city_info")
+        val actualRows = getTableRows(dataSource, TEST_DATABASE, "city__city_info")
         assertEquals(expectedRows, actualRows)
     }
 
@@ -172,18 +172,18 @@ class SetCreateTests {
         val actualResponse = set(create, setEntityDelegates, dataSource, clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
-            |= Table main${'$'}address_book_root =
+            |= Table main__address_book_root =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book
-            |singleton_key${'$'}: 0
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book
+            |singleton_key_: 0
             |name: null
             |last_updated: null
             |
         """.trimMargin()
-        val actualRows = getTableRows(dataSource, TEST_DATABASE, "main\$address_book_root")
+        val actualRows = getTableRows(dataSource, TEST_DATABASE, "main__address_book_root")
         assertEquals(expectedRows, actualRows)
     }
 
@@ -208,30 +208,30 @@ class SetCreateTests {
         val actualResponse = set(create, setEntityDelegates, dataSource, clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
-            |= Table main${'$'}address_book_root =
+            |= Table main__address_book_root =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book
-            |singleton_key${'$'}: 0
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book
+            |singleton_key_: 0
             |name: null
             |last_updated: null
             |
-            |= Table main${'$'}address_book_settings =
+            |= Table main__address_book_settings =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book/settings
-            |main${'$'}address_book_root${'$'}singleton_key${'$'}: 0
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book/settings
+            |main__address_book_root__singleton_key_: 0
             |last_name_first: 1
             |encrypt_hero_name: null
             |card_colors: null
             |
         """.trimMargin()
         val actualRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_root", "main\$address_book_settings")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_root", "main__address_book_settings")
         assertEquals(expectedRows, actualRows)
     }
 
@@ -255,30 +255,30 @@ class SetCreateTests {
         val actualResponse = set(create, setEntityDelegates, dataSource, clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
-            |= Table main${'$'}address_book_root =
+            |= Table main__address_book_root =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book
-            |singleton_key${'$'}: 0
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book
+            |singleton_key_: 0
             |name: null
             |last_updated: null
             |
-            |= Table main${'$'}address_book_settings =
+            |= Table main__address_book_settings =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book/settings
-            |main${'$'}address_book_root${'$'}singleton_key${'$'}: 0
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book/settings
+            |main__address_book_root__singleton_key_: 0
             |last_name_first: null
             |encrypt_hero_name: null
             |card_colors: null
             |
         """.trimMargin()
         val actualRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_root", "main\$address_book_settings")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_root", "main__address_book_settings")
         assertEquals(expectedRows, actualRows)
     }
 
@@ -305,13 +305,13 @@ class SetCreateTests {
         val actualResponse = set(create, setEntityDelegates, dataSource, clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
-            |= Table main${'$'}address_book_person =
+            |= Table main__address_book_person =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-14 00:40:41.450
-            |updated_on${'$'}: 2022-04-14 00:40:41.450
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-04-14 00:40:41.450
+            |updated_on_: 2022-04-14 00:40:41.450
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |first_name: null
             |last_name: null
@@ -319,10 +319,10 @@ class SetCreateTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
         """.trimMargin()
-        val actualRows = getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person")
+        val actualRows = getTableRows(dataSource, TEST_DATABASE, "main__address_book_person")
         assertEquals(expectedRows, actualRows)
     }
 

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetDeleteTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetDeleteTests.kt
@@ -24,7 +24,7 @@ import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetKeylessEntityTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetKeylessEntityTests.kt
@@ -25,7 +25,7 @@ import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 
@@ -59,7 +59,7 @@ class SetKeylessEntityTests {
 
 
     private fun getKeylessTableRows(): String =
-        getTableRows(dataSource, TEST_DATABASE, "keyless\$keyless", "keyless\$keyless_child", "keyless\$keyed_child")
+        getTableRows(dataSource, TEST_DATABASE, "keyless__keyless", "keyless__keyless_child", "keyless__keyed_child")
 
     @Test
     fun `set() must succeed when creating new keyless entities`() {

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetMixedTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetMixedTests.kt
@@ -23,7 +23,7 @@ import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 
@@ -101,13 +101,13 @@ class SetMixedTests {
         val actualCreateResponse = set(create, setEntityDelegates, dataSource, clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = """
-            |= Table main${'$'}address_book_person =
+            |= Table main__address_book_person =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |first_name: Lois
             |last_name: Lane
@@ -115,13 +115,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
             |* Row 2 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |first_name: Clark
             |last_name: Kent
@@ -129,24 +129,24 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
-            |= Table main${'$'}address_book_relation =
+            |= Table main__address_book_relation =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-            |main${'$'}person_group${'$'}id: null
-            |main${'$'}address_book_person${'$'}id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+            |main__person_group__id: null
+            |main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |id: 05ade278-4b44-43da-a0cc-14463854e397
             |relationship: 7
             |person: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-            |person${'$'}id: a8aacf55-7810-4b43-afe5-4344f25435fd
+            |person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |
         """.trimMargin()
         val afterCreateRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person", "main\$address_book_relation")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
         assertEquals(afterCreateRowsExpected, afterCreateRows)
 
         val mixedJson = """
@@ -189,13 +189,13 @@ class SetMixedTests {
         val actualMixedResponse = set(mixed, setEntityDelegates, dataSource, clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRowsExpected = """
-            |= Table main${'$'}address_book_person =
+            |= Table main__address_book_person =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |first_name: Lois
             |last_name: Lane
@@ -203,13 +203,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
             |* Row 2 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |first_name: Clark
             |last_name: Kent
@@ -217,13 +217,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
             |* Row 3 *
-            |created_on${'$'}: 2022-04-04 00:40:41.440
-            |updated_on${'$'}: 2022-04-04 00:40:41.440
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-04-04 00:40:41.440
+            |updated_on_: 2022-04-04 00:40:41.440
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: ec983c56-320f-4d66-9dde-f180e8ac3807
             |first_name: Jimmy
             |last_name: Olsen
@@ -231,24 +231,24 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
-            |= Table main${'$'}address_book_relation =
+            |= Table main__address_book_relation =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-04-04 00:40:41.440
-            |field_path${'$'}: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-            |main${'$'}person_group${'$'}id: null
-            |main${'$'}address_book_person${'$'}id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-04-04 00:40:41.440
+            |field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+            |main__person_group__id: null
+            |main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |id: 05ade278-4b44-43da-a0cc-14463854e397
             |relationship: 7
             |person: {"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}
-            |person${'$'}id: ec983c56-320f-4d66-9dde-f180e8ac3807
+            |person__id: ec983c56-320f-4d66-9dde-f180e8ac3807
             |
         """.trimMargin()
         val afterMixedRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person", "main\$address_book_relation")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
         assertEquals(afterMixedRowsExpected, afterMixedRows)
     }
 
@@ -302,13 +302,13 @@ class SetMixedTests {
         val actualCreateResponse = set(create, setEntityDelegates, dataSource, clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = """
-            |= Table main${'$'}address_book_person =
+            |= Table main__address_book_person =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |first_name: Lois
             |last_name: Lane
@@ -316,13 +316,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
             |* Row 2 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |first_name: Clark
             |last_name: Kent
@@ -330,13 +330,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
             |* Row 3 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: ec983c56-320f-4d66-9dde-f180e8ac3807
             |first_name: Jimmy
             |last_name: Olsen
@@ -344,24 +344,24 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
-            |= Table main${'$'}address_book_relation =
+            |= Table main__address_book_relation =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-            |main${'$'}person_group${'$'}id: null
-            |main${'$'}address_book_person${'$'}id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+            |main__person_group__id: null
+            |main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |id: 05ade278-4b44-43da-a0cc-14463854e397
             |relationship: 7
             |person: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-            |person${'$'}id: a8aacf55-7810-4b43-afe5-4344f25435fd
+            |person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |
         """.trimMargin()
         val afterCreateRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person", "main\$address_book_relation")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
         assertEquals(afterCreateRowsExpected, afterCreateRows)
 
         val mixedJson = """
@@ -410,7 +410,7 @@ class SetMixedTests {
         val actualMixedResponse = set(mixed, setEntityDelegates, dataSource, clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person", "main\$address_book_relation")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
         assertEquals(afterCreateRowsExpected, afterMixedRows)
     }
 
@@ -446,13 +446,13 @@ class SetMixedTests {
         val actualCreateResponse = set(create, setEntityDelegates, dataSource, clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = """
-            |= Table main${'$'}address_book_person =
+            |= Table main__address_book_person =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: a8aacf55-7810-4b43-afe5-4344f25435fd
             |first_name: Lois
             |last_name: Lane
@@ -460,13 +460,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
             |* Row 2 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book/person
-            |main${'$'}person_group${'$'}id: null
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book/person
+            |main__person_group__id: null
             |id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
             |first_name: Clark
             |last_name: Kent
@@ -474,13 +474,13 @@ class SetMixedTests {
             |email: null
             |picture: null
             |self: null
-            |self${'$'}id: null
+            |self__id: null
             |
-            |= Table main${'$'}address_book_relation =
+            |= Table main__address_book_relation =
             |
         """.trimMargin()
         val afterCreateRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person", "main\$address_book_relation")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
         assertEquals(afterCreateRowsExpected, afterCreateRows)
 
         val mixedJson = """
@@ -530,7 +530,7 @@ class SetMixedTests {
         val actualMixedResponse = set(mixed, setEntityDelegates, dataSource, clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRows =
-            getTableRows(dataSource, TEST_DATABASE, "main\$address_book_person", "main\$address_book_relation")
+            getTableRows(dataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
         assertEquals(afterCreateRowsExpected, afterMixedRows)
     }
 

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetSingletonEntityTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetSingletonEntityTests.kt
@@ -25,7 +25,7 @@ import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 
@@ -62,9 +62,9 @@ class SetSingletonEntityTests {
         getTableRows(
             dataSource,
             TEST_DATABASE,
-            "main\$address_book_root",
-            "main\$address_book_settings",
-            "main\$advanced_settings"
+            "main__address_book_root",
+            "main__address_book_settings",
+            "main__advanced_settings"
         )
 
     @Test
@@ -276,19 +276,19 @@ class SetSingletonEntityTests {
         val actualCreateRootResponse = set(createRoot, setEntityDelegates, dataSource, clock = createClock)
         assertSetResponse(expectedCreateRootResponse, actualCreateRootResponse)
         val afterCreateRootRowsExpected = """
-            |= Table main${'$'}address_book_root =
+            |= Table main__address_book_root =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book
-            |singleton_key${'$'}: 0
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book
+            |singleton_key_: 0
             |name: Super Heroes
             |last_updated: null
             |
-            |= Table main${'$'}address_book_settings =
+            |= Table main__address_book_settings =
             |
-            |= Table main${'$'}advanced_settings =
+            |= Table main__advanced_settings =
             |
         """.trimMargin()
         val afterCreateRootRows = getSingletonTableRows()
@@ -317,34 +317,34 @@ class SetSingletonEntityTests {
         val actualCreateChildrenResponse = set(createChildren, setEntityDelegates, dataSource, clock = updateClock)
         assertSetResponse(expectedCreateChildrenResponse, actualCreateChildrenResponse)
         val afterCreateChildrenRowsExpected = """
-            |= Table main${'$'}address_book_root =
+            |= Table main__address_book_root =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-03-03 00:30:31.330
-            |updated_on${'$'}: 2022-03-03 00:30:31.330
-            |field_path${'$'}: /address_book
-            |singleton_key${'$'}: 0
+            |created_on_: 2022-03-03 00:30:31.330
+            |updated_on_: 2022-03-03 00:30:31.330
+            |field_path_: /address_book
+            |singleton_key_: 0
             |name: Super Heroes
             |last_updated: null
             |
-            |= Table main${'$'}address_book_settings =
+            |= Table main__address_book_settings =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-04 00:40:41.440
-            |updated_on${'$'}: 2022-04-04 00:40:41.440
-            |field_path${'$'}: /address_book/settings
-            |main${'$'}address_book_root${'$'}singleton_key${'$'}: 0
+            |created_on_: 2022-04-04 00:40:41.440
+            |updated_on_: 2022-04-04 00:40:41.440
+            |field_path_: /address_book/settings
+            |main__address_book_root__singleton_key_: 0
             |last_name_first: 1
             |encrypt_hero_name: null
             |card_colors: null
             |
-            |= Table main${'$'}advanced_settings =
+            |= Table main__advanced_settings =
             |
             |* Row 1 *
-            |created_on${'$'}: 2022-04-04 00:40:41.440
-            |updated_on${'$'}: 2022-04-04 00:40:41.440
-            |field_path${'$'}: /address_book/settings/advanced
-            |main${'$'}address_book_root${'$'}singleton_key${'$'}: 0
+            |created_on_: 2022-04-04 00:40:41.440
+            |updated_on_: 2022-04-04 00:40:41.440
+            |field_path_: /address_book/settings/advanced
+            |main__address_book_root__singleton_key_: 0
             |background_color: 3
             |
         """.trimMargin()

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetUpdateTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetUpdateTests.kt
@@ -24,7 +24,7 @@ import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-private const val TEST_DATABASE = "test\$address_book"
+private const val TEST_DATABASE = "test__address_book"
 
 private val auxDecodingFactory = MultiAuxDecodingStateMachineFactory(SET_AUX_NAME to { SetAuxStateMachine(it) })
 

--- a/src/test/resources/operator/forward_referencing_association_set_create_results.txt
+++ b/src/test/resources/operator/forward_referencing_association_set_create_results.txt
@@ -1,24 +1,24 @@
-+ Database test$address_book +
++ Database test__address_book +
 
-= Table city$city_info =
+= Table city__city_info =
 
-= Table crypto$password =
+= Table crypto__password =
 
-= Table crypto$secret =
+= Table crypto__secret =
 
-= Table keyless$keyed_child =
+= Table keyless__keyed_child =
 
-= Table keyless$keyless =
+= Table keyless__keyless =
 
-= Table keyless$keyless_child =
+= Table keyless__keyless_child =
 
-= Table main$address_book_person =
+= Table main__address_book_person =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person
+main__person_group__id: null
 id: a8aacf55-7810-4b43-afe5-4344f25435fd
 first_name: null
 last_name: null
@@ -26,13 +26,13 @@ hero_name: null
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person
+main__person_group__id: null
 id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 first_name: null
 last_name: null
@@ -40,33 +40,33 @@ hero_name: null
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
-= Table main$address_book_relation =
+= Table main__address_book_relation =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 id: 05ade278-4b44-43da-a0cc-14463854e397
 relationship: null
 person: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 
-= Table main$address_book_root =
+= Table main__address_book_root =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book
-singleton_key$: 0
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book
+singleton_key_: 0
 name: Super Heroes
 last_updated: null
 
-= Table main$address_book_settings =
+= Table main__address_book_settings =
 
-= Table main$advanced_settings =
+= Table main__advanced_settings =
 
-= Table main$person_group =
+= Table main__person_group =

--- a/src/test/resources/operator/my_sql_address_book_1_set_create_commands.sql
+++ b/src/test/resources/operator/my_sql_address_book_1_set_create_commands.sql
@@ -1,109 +1,109 @@
-INSERT INTO test$address_book.main$address_book_root
-  (created_on$, updated_on$, field_path$, singleton_key$, name, last_updated)
+INSERT INTO test__address_book.main__address_book_root
+  (created_on_, updated_on_, field_path_, singleton_key_, name, last_updated)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book', 0, 'Super Heroes', '2022-04-19T17:52:57');
-INSERT INTO test$address_book.main$address_book_settings
-  (created_on$, updated_on$, field_path$, main$address_book_root$singleton_key$, last_name_first, encrypt_hero_name, card_colors)
+INSERT INTO test__address_book.main__address_book_settings
+  (created_on_, updated_on_, field_path_, main__address_book_root__singleton_key_, last_name_first, encrypt_hero_name, card_colors)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/settings', 0, true, false, '[{"value":"orange"},{"value":"green"},{"value":"blue"}]');
-INSERT INTO test$address_book.main$advanced_settings
-  (created_on$, updated_on$, field_path$, main$address_book_root$singleton_key$, background_color)
+INSERT INTO test__address_book.main__advanced_settings
+  (created_on_, updated_on_, field_path_, main__address_book_root__singleton_key_, background_color)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/settings/advanced', 0, 3);
-INSERT INTO test$address_book.main$address_book_person
-  (created_on$, updated_on$, field_path$, id, first_name, last_name, hero_name, email, picture)
+INSERT INTO test__address_book.main__address_book_person
+  (created_on_, updated_on_, field_path_, id, first_name, last_name, hero_name, email, picture)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person', UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), 'Clark', 'Kent', 'Superman', '[{"value":"clark.kent@dailyplanet.com"},{"value":"superman@dc.com"}]', 0x50696374757265206f6620436c61726b204b656e74);
-INSERT INTO test$address_book.main$address_book_relation
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, id, relationship)
+INSERT INTO test__address_book.main__address_book_relation
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, id, relationship)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation', UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397'), 7);
-INSERT INTO test$address_book.main$address_book_relation
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, id, relationship)
+INSERT INTO test__address_book.main__address_book_relation
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, id, relationship)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation', UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce'), 7);
-INSERT INTO test$address_book.crypto$password
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, previous)
+INSERT INTO test__address_book.crypto__password
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, previous)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password', UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), '[{"hashed":"test-hashed-superman","hash_version":1}]');
-INSERT INTO test$address_book.crypto$secret
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, other)
+INSERT INTO test__address_book.crypto__secret
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, other)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret', UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), '[{"encrypted":"test-encrypted-secret2","cipher_version":1}]');
-INSERT INTO test$address_book.main$address_book_person
-  (created_on$, updated_on$, field_path$, id, first_name, last_name, email, picture)
+INSERT INTO test__address_book.main__address_book_person
+  (created_on_, updated_on_, field_path_, id, first_name, last_name, email, picture)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person', UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), 'Lois', 'Lane', '[{"value":"lois.lane@dailyplanet.com"}]', 0x50696374757265206f66204c6f6973204c616e65);
-INSERT INTO test$address_book.main$address_book_relation
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, id, relationship)
+INSERT INTO test__address_book.main__address_book_relation
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, id, relationship)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation', UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b'), 7);
-INSERT INTO test$address_book.crypto$password
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, current, previous)
+INSERT INTO test__address_book.crypto__password
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, current, previous)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password', UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), '{"hashed":"test-hashed-lois","hash_version":1}', '[{"hashed":"test-hashed-password2","hash_version":1}]');
-INSERT INTO test$address_book.crypto$secret
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, main, other)
+INSERT INTO test__address_book.crypto__secret
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, main, other)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret', UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), '{"encrypted":"test-encrypted-main-secret","cipher_version":1}', '[{"encrypted":"test-encrypted-secret2","cipher_version":1}]');
-INSERT INTO test$address_book.main$address_book_person
-  (created_on$, updated_on$, field_path$, id, first_name, last_name)
+INSERT INTO test__address_book.main__address_book_person
+  (created_on_, updated_on_, field_path_, id, first_name, last_name)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person', UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), 'Jimmy', 'Olsen');
-INSERT INTO test$address_book.main$person_group
-  (created_on$, updated_on$, field_path$, id, name)
+INSERT INTO test__address_book.main__person_group
+  (created_on_, updated_on_, field_path_, id, name)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/groups', UUID_TO_BIN('ca0a22e8-c300-4347-91b0-167a5f6f4f9a'), 'DC');
-INSERT INTO test$address_book.main$person_group
-  (created_on$, updated_on$, field_path$, main$person_group$id, id, name)
+INSERT INTO test__address_book.main__person_group
+  (created_on_, updated_on_, field_path_, main__person_group__id, id, name)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups', UUID_TO_BIN('ca0a22e8-c300-4347-91b0-167a5f6f4f9a'), UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc'), 'Superman');
-INSERT INTO test$address_book.main$address_book_person
-  (created_on$, updated_on$, field_path$, main$person_group$id, id, first_name, last_name, hero_name)
+INSERT INTO test__address_book.main__address_book_person
+  (created_on_, updated_on_, field_path_, main__person_group__id, id, first_name, last_name, hero_name)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons', UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc'), UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0'), 'Clark', 'Kent', 'Superman');
-INSERT INTO test$address_book.main$address_book_person
-  (created_on$, updated_on$, field_path$, main$person_group$id, id, first_name, last_name)
+INSERT INTO test__address_book.main__address_book_person
+  (created_on_, updated_on_, field_path_, main__person_group__id, id, first_name, last_name)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons', UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc'), UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7'), 'Lois', 'Lane');
-INSERT INTO test$address_book.main$person_group
-  (created_on$, updated_on$, field_path$, id, name)
+INSERT INTO test__address_book.main__person_group
+  (created_on_, updated_on_, field_path_, id, name)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/groups', UUID_TO_BIN('ad9aaea8-30fe-45ed-93ef-bd368da0c756'), 'Marvel');
-INSERT INTO test$address_book.city$city_info
-  (created_on$, updated_on$, field_path$, name, state, country, info, latitude, longitude, city_center)
+INSERT INTO test__address_book.city__city_info
+  (created_on_, updated_on_, field_path_, name, state, country, info, latitude, longitude, city_center)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/city_info', 'New York City', 'New York', 'United States of America', 'One of the most populous and most densely populated major city in USA', 40.712982, -74.007205, ST_SRID(Point(-74.007205, 40.712982), 4326));
-INSERT INTO test$address_book.city$city_info
-  (created_on$, updated_on$, field_path$, name, state, country, info, latitude, longitude, city_center)
+INSERT INTO test__address_book.city__city_info
+  (created_on_, updated_on_, field_path_, name, state, country, info, latitude, longitude, city_center)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/city_info', 'Albany', 'New York', 'United States of America', 'Capital of New York state', 42.651934, -73.75477, ST_SRID(Point(-73.75477, 42.651934), 4326));
-INSERT INTO test$address_book.city$city_info
-  (created_on$, updated_on$, field_path$, name, state, country, info, latitude, longitude, city_center)
+INSERT INTO test__address_book.city__city_info
+  (created_on_, updated_on_, field_path_, name, state, country, info, latitude, longitude, city_center)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/city_info', 'Princeton', 'New Jersey', 'United States of America', 'Home of Princeton University', 40.360594, -74.664441, ST_SRID(Point(-74.664441, 40.360594), 4326));
-INSERT INTO test$address_book.city$city_info
-  (created_on$, updated_on$, field_path$, name, state, country, info, latitude, longitude, city_center)
+INSERT INTO test__address_book.city__city_info
+  (created_on_, updated_on_, field_path_, name, state, country, info, latitude, longitude, city_center)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/city_info', 'San Francisco', 'California', 'United States of America', 'The cultural and financial center of Northern California', 37.779379, -122.418433, ST_SRID(Point(-122.418433, 37.779379), 4326));
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), person = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}'
-  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), person = '{"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}'
-  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-UPDATE test$address_book.main$address_book_person
-  SET updated_on$ = '2022-04-14T00:40:41.450', self$id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), self = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}'
-  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path$ = '/address_book/person';
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), person = '{"person":[{"id":"cc477201-48ec-4367-83a4-7fdbd92f8a6f"}]}'
-  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"Albany","state":"New York","country":"United States of America"}]},{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}]'
-  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"New York City","state":"New York","country":"United States of America"}]}]'
-  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[]', self$name = 'Princeton', self$state = 'New Jersey', self$country = 'United States of America', self = '{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}', self2$name = 'Princeton', self2$state = 'New Jersey', self2$country = 'United States of America', self2 = '{"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}'
-  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), person = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}'
+  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), person = '{"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}'
+  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.main__address_book_person
+  SET updated_on_ = '2022-04-14T00:40:41.450', self__id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), self = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}'
+  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path_ = '/address_book/person';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), person = '{"person":[{"id":"cc477201-48ec-4367-83a4-7fdbd92f8a6f"}]}'
+  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"Albany","state":"New York","country":"United States of America"}]},{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}]'
+  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"New York City","state":"New York","country":"United States of America"}]}]'
+  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[]', self__name = 'Princeton', self__state = 'New Jersey', self__country = 'United States of America', self = '{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}', self2__name = 'Princeton', self2__state = 'New Jersey', self2__country = 'United States of America', self2 = '{"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}'
+  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';

--- a/src/test/resources/operator/my_sql_address_book_1_set_create_results.txt
+++ b/src/test/resources/operator/my_sql_address_book_1_set_create_results.txt
@@ -1,11 +1,11 @@
-+ Database test$address_book +
++ Database test__address_book +
 
-= Table city$city_info =
+= Table city__city_info =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/city_info
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/city_info
 name: Albany
 state: New York
 country: United States of America
@@ -15,18 +15,18 @@ longitude: -73.75477
 city_center: Point(latitude: 42.651934, longitude: -73.75477, SRID: 4326)
 related_city_info: [{"city_info": [{"name": "New York City", "state": "New York", "country": "United States of America"}]}]
 self: null
-self$name: null
-self$state: null
-self$country: null
+self__name: null
+self__state: null
+self__country: null
 self2: null
-self2$name: null
-self2$state: null
-self2$country: null
+self2__name: null
+self2__state: null
+self2__country: null
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/city_info
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/city_info
 name: New York City
 state: New York
 country: United States of America
@@ -36,18 +36,18 @@ longitude: -74.007205
 city_center: Point(latitude: 40.712982, longitude: -74.007205, SRID: 4326)
 related_city_info: [{"city_info": [{"name": "Albany", "state": "New York", "country": "United States of America"}]}, {"city_info": [{"name": "Princeton", "state": "New Jersey", "country": "United States of America"}]}]
 self: null
-self$name: null
-self$state: null
-self$country: null
+self__name: null
+self__state: null
+self__country: null
 self2: null
-self2$name: null
-self2$state: null
-self2$country: null
+self2__name: null
+self2__state: null
+self2__country: null
 
 * Row 3 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/city_info
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/city_info
 name: Princeton
 state: New Jersey
 country: United States of America
@@ -57,18 +57,18 @@ longitude: -74.664441
 city_center: Point(latitude: 40.360594, longitude: -74.664441, SRID: 4326)
 related_city_info: []
 self: {"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}
-self$name: Princeton
-self$state: New Jersey
-self$country: United States of America
+self__name: Princeton
+self__state: New Jersey
+self__country: United States of America
 self2: {"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}
-self2$name: Princeton
-self2$state: New Jersey
-self2$country: United States of America
+self2__name: Princeton
+self2__state: New Jersey
+self2__country: United States of America
 
 * Row 4 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/city_info
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/city_info
 name: San Francisco
 state: California
 country: United States of America
@@ -78,67 +78,67 @@ longitude: -122.418433
 city_center: Point(latitude: 37.779379, longitude: -122.418433, SRID: 4326)
 related_city_info: null
 self: null
-self$name: null
-self$state: null
-self$country: null
+self__name: null
+self__state: null
+self__country: null
 self2: null
-self2$name: null
-self2$state: null
-self2$country: null
+self2__name: null
+self2__state: null
+self2__country: null
 
-= Table crypto$password =
+= Table crypto__password =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 current: null
 previous: [{"hashed": "test-hashed-superman", "hash_version": 1}]
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password
-main$person_group$id: null
-main$address_book_person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password
+main__person_group__id: null
+main__address_book_person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 current: {"hashed": "test-hashed-lois", "hash_version": 1}
 previous: [{"hashed": "test-hashed-password2", "hash_version": 1}]
 
-= Table crypto$secret =
+= Table crypto__secret =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 main: null
 other: [{"encrypted": "test-encrypted-secret2", "cipher_version": 1}]
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret
-main$person_group$id: null
-main$address_book_person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret
+main__person_group__id: null
+main__address_book_person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 main: {"encrypted": "test-encrypted-main-secret", "cipher_version": 1}
 other: [{"encrypted": "test-encrypted-secret2", "cipher_version": 1}]
 
-= Table keyless$keyed_child =
+= Table keyless__keyed_child =
 
-= Table keyless$keyless =
+= Table keyless__keyless =
 
-= Table keyless$keyless_child =
+= Table keyless__keyless_child =
 
-= Table main$address_book_person =
+= Table main__address_book_person =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
-main$person_group$id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
+main__person_group__id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
 id: 546a4982-b39a-4d01-aeb3-22d60c6963c0
 first_name: Clark
 last_name: Kent
@@ -146,13 +146,13 @@ hero_name: Superman
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person
+main__person_group__id: null
 id: a8aacf55-7810-4b43-afe5-4344f25435fd
 first_name: Lois
 last_name: Lane
@@ -160,13 +160,13 @@ hero_name: null
 email: [{"value": "lois.lane@dailyplanet.com"}]
 picture: Picture of Lois Lane
 self: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-self$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+self__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 
 * Row 3 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person
+main__person_group__id: null
 id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 first_name: Clark
 last_name: Kent
@@ -174,13 +174,13 @@ hero_name: Superman
 email: [{"value": "clark.kent@dailyplanet.com"}, {"value": "superman@dc.com"}]
 picture: Picture of Clark Kent
 self: null
-self$id: null
+self__id: null
 
 * Row 4 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
-main$person_group$id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
+main__person_group__id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
 id: e391c509-67d6-4846-bfea-0f7cd9c91bf7
 first_name: Lois
 last_name: Lane
@@ -188,13 +188,13 @@ hero_name: null
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
 * Row 5 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person
+main__person_group__id: null
 id: ec983c56-320f-4d66-9dde-f180e8ac3807
 first_name: Jimmy
 last_name: Olsen
@@ -202,95 +202,95 @@ hero_name: null
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
-= Table main$address_book_relation =
+= Table main__address_book_relation =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 id: 05ade278-4b44-43da-a0cc-14463854e397
 relationship: 7
 person: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation
-main$person_group$id: null
-main$address_book_person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation
+main__person_group__id: null
+main__address_book_person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 id: 16634916-8f83-4376-ad42-37038e108a0b
 relationship: 7
 person: {"person":[{"id":"cc477201-48ec-4367-83a4-7fdbd92f8a6f"}]}
-person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 
 * Row 3 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 id: 3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce
 relationship: 7
 person: {"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}
-person$id: ec983c56-320f-4d66-9dde-f180e8ac3807
+person__id: ec983c56-320f-4d66-9dde-f180e8ac3807
 
-= Table main$address_book_root =
+= Table main__address_book_root =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book
-singleton_key$: 0
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book
+singleton_key_: 0
 name: Super Heroes
 last_updated: 2022-04-19 17:52:57
 
-= Table main$address_book_settings =
+= Table main__address_book_settings =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/settings
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/settings
+main__address_book_root__singleton_key_: 0
 last_name_first: 1
 encrypt_hero_name: 0
 card_colors: [{"value": "orange"}, {"value": "green"}, {"value": "blue"}]
 
-= Table main$advanced_settings =
+= Table main__advanced_settings =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/settings/advanced
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/settings/advanced
+main__address_book_root__singleton_key_: 0
 background_color: 3
 
-= Table main$person_group =
+= Table main__person_group =
 
 * Row 1 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/groups
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/groups
+main__person_group__id: null
 id: ad9aaea8-30fe-45ed-93ef-bd368da0c756
 name: Marvel
 
 * Row 2 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/groups
-main$person_group$id: null
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/groups
+main__person_group__id: null
 id: ca0a22e8-c300-4347-91b0-167a5f6f4f9a
 name: DC
 
 * Row 3 *
-created_on$: 2022-04-14 00:40:41.450
-updated_on$: 2022-04-14 00:40:41.450
-field_path$: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups
-main$person_group$id: ca0a22e8-c300-4347-91b0-167a5f6f4f9a
+created_on_: 2022-04-14 00:40:41.450
+updated_on_: 2022-04-14 00:40:41.450
+field_path_: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups
+main__person_group__id: ca0a22e8-c300-4347-91b0-167a5f6f4f9a
 id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
 name: Superman

--- a/src/test/resources/operator/my_sql_address_book_1_set_delete_bottoms_up_commands.sql
+++ b/src/test/resources/operator/my_sql_address_book_1_set_delete_bottoms_up_commands.sql
@@ -1,80 +1,80 @@
-UPDATE test$address_book.main$address_book_person
-  SET self$id = NULL
-  WHERE id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f') AND field_path$ = '/address_book/person';
-UPDATE test$address_book.main$address_book_relation
-  SET person$id = NULL
-  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-UPDATE test$address_book.main$address_book_relation
-  SET person$id = NULL
-  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-UPDATE test$address_book.main$address_book_person
-  SET self$id = NULL
-  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path$ = '/address_book/person';
-UPDATE test$address_book.main$address_book_relation
-  SET person$id = NULL
-  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
-UPDATE test$address_book.main$address_book_person
-  SET self$id = NULL
-  WHERE id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807') AND field_path$ = '/address_book/person';
-UPDATE test$address_book.main$address_book_person
-  SET self$id = NULL
-  WHERE id = UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
-UPDATE test$address_book.main$address_book_person
-  SET self$id = NULL
-  WHERE id = UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
-UPDATE test$address_book.city$city_info
-  SET related_city_info = NULL, self$name = NULL, self$state = NULL, self$country = NULL, self2$name = NULL, self2$state = NULL, self2$country = NULL
-  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET related_city_info = NULL, self$name = NULL, self$state = NULL, self$country = NULL, self2$name = NULL, self2$state = NULL, self2$country = NULL
-  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET related_city_info = NULL, self$name = NULL, self$state = NULL, self$country = NULL, self2$name = NULL, self2$state = NULL, self2$country = NULL
-  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET related_city_info = NULL, self$name = NULL, self$state = NULL, self$country = NULL, self2$name = NULL, self2$state = NULL, self2$country = NULL
-  WHERE name = 'San Francisco' AND state = 'California' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-DELETE FROM test$address_book.city$city_info
-  WHERE name = 'San Francisco' AND state = 'California' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-DELETE FROM test$address_book.city$city_info
-  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-DELETE FROM test$address_book.city$city_info
-  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-DELETE FROM test$address_book.city$city_info
-  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-DELETE FROM test$address_book.main$person_group
-  WHERE id = UUID_TO_BIN('ad9aaea8-30fe-45ed-93ef-bd368da0c756') AND field_path$ = '/address_book/groups';
-DELETE FROM test$address_book.main$address_book_person
-  WHERE id = UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
-DELETE FROM test$address_book.main$address_book_person
-  WHERE id = UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
-DELETE FROM test$address_book.main$person_group
-  WHERE id = UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups';
-DELETE FROM test$address_book.main$person_group
-  WHERE id = UUID_TO_BIN('ca0a22e8-c300-4347-91b0-167a5f6f4f9a') AND field_path$ = '/address_book/groups';
-DELETE FROM test$address_book.main$address_book_person
-  WHERE id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807') AND field_path$ = '/address_book/person';
-DELETE FROM test$address_book.crypto$secret
-  WHERE field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret';
-DELETE FROM test$address_book.crypto$password
-  WHERE field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password';
-DELETE FROM test$address_book.main$address_book_relation
-  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
-DELETE FROM test$address_book.main$address_book_person
-  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path$ = '/address_book/person';
-DELETE FROM test$address_book.crypto$secret
-  WHERE field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret';
-DELETE FROM test$address_book.crypto$password
-  WHERE field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password';
-DELETE FROM test$address_book.main$address_book_relation
-  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-DELETE FROM test$address_book.main$address_book_relation
-  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-DELETE FROM test$address_book.main$address_book_person
-  WHERE id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f') AND field_path$ = '/address_book/person';
-DELETE FROM test$address_book.main$advanced_settings
-  WHERE field_path$ = '/address_book/settings/advanced';
-DELETE FROM test$address_book.main$address_book_settings
-  WHERE field_path$ = '/address_book/settings';
-DELETE FROM test$address_book.main$address_book_root
-  WHERE field_path$ = '/address_book';
+UPDATE test__address_book.main__address_book_person
+  SET self__id = NULL
+  WHERE id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f') AND field_path_ = '/address_book/person';
+UPDATE test__address_book.main__address_book_relation
+  SET person__id = NULL
+  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.main__address_book_relation
+  SET person__id = NULL
+  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.main__address_book_person
+  SET self__id = NULL
+  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path_ = '/address_book/person';
+UPDATE test__address_book.main__address_book_relation
+  SET person__id = NULL
+  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
+UPDATE test__address_book.main__address_book_person
+  SET self__id = NULL
+  WHERE id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807') AND field_path_ = '/address_book/person';
+UPDATE test__address_book.main__address_book_person
+  SET self__id = NULL
+  WHERE id = UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
+UPDATE test__address_book.main__address_book_person
+  SET self__id = NULL
+  WHERE id = UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
+UPDATE test__address_book.city__city_info
+  SET related_city_info = NULL, self__name = NULL, self__state = NULL, self__country = NULL, self2__name = NULL, self2__state = NULL, self2__country = NULL
+  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET related_city_info = NULL, self__name = NULL, self__state = NULL, self__country = NULL, self2__name = NULL, self2__state = NULL, self2__country = NULL
+  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET related_city_info = NULL, self__name = NULL, self__state = NULL, self__country = NULL, self2__name = NULL, self2__state = NULL, self2__country = NULL
+  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET related_city_info = NULL, self__name = NULL, self__state = NULL, self__country = NULL, self2__name = NULL, self2__state = NULL, self2__country = NULL
+  WHERE name = 'San Francisco' AND state = 'California' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+DELETE FROM test__address_book.city__city_info
+  WHERE name = 'San Francisco' AND state = 'California' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+DELETE FROM test__address_book.city__city_info
+  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+DELETE FROM test__address_book.city__city_info
+  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+DELETE FROM test__address_book.city__city_info
+  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+DELETE FROM test__address_book.main__person_group
+  WHERE id = UUID_TO_BIN('ad9aaea8-30fe-45ed-93ef-bd368da0c756') AND field_path_ = '/address_book/groups';
+DELETE FROM test__address_book.main__address_book_person
+  WHERE id = UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
+DELETE FROM test__address_book.main__address_book_person
+  WHERE id = UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
+DELETE FROM test__address_book.main__person_group
+  WHERE id = UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups';
+DELETE FROM test__address_book.main__person_group
+  WHERE id = UUID_TO_BIN('ca0a22e8-c300-4347-91b0-167a5f6f4f9a') AND field_path_ = '/address_book/groups';
+DELETE FROM test__address_book.main__address_book_person
+  WHERE id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807') AND field_path_ = '/address_book/person';
+DELETE FROM test__address_book.crypto__secret
+  WHERE field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret';
+DELETE FROM test__address_book.crypto__password
+  WHERE field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password';
+DELETE FROM test__address_book.main__address_book_relation
+  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
+DELETE FROM test__address_book.main__address_book_person
+  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path_ = '/address_book/person';
+DELETE FROM test__address_book.crypto__secret
+  WHERE field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret';
+DELETE FROM test__address_book.crypto__password
+  WHERE field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password';
+DELETE FROM test__address_book.main__address_book_relation
+  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+DELETE FROM test__address_book.main__address_book_relation
+  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+DELETE FROM test__address_book.main__address_book_person
+  WHERE id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f') AND field_path_ = '/address_book/person';
+DELETE FROM test__address_book.main__advanced_settings
+  WHERE field_path_ = '/address_book/settings/advanced';
+DELETE FROM test__address_book.main__address_book_settings
+  WHERE field_path_ = '/address_book/settings';
+DELETE FROM test__address_book.main__address_book_root
+  WHERE field_path_ = '/address_book';

--- a/src/test/resources/operator/my_sql_address_book_1_set_mixed_commands.sql
+++ b/src/test/resources/operator/my_sql_address_book_1_set_mixed_commands.sql
@@ -1,15 +1,15 @@
-UPDATE test$address_book.main$address_book_person
-  SET self$id = NULL
-  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path$ = '/address_book/person';
-DELETE FROM test$address_book.main$address_book_person
-  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path$ = '/address_book/person';
-INSERT INTO test$address_book.main$address_book_relation
-  (created_on$, updated_on$, field_path$, main$address_book_person$id, id)
+UPDATE test__address_book.main__address_book_person
+  SET self__id = NULL
+  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path_ = '/address_book/person';
+DELETE FROM test__address_book.main__address_book_person
+  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path_ = '/address_book/person';
+INSERT INTO test__address_book.main__address_book_relation
+  (created_on_, updated_on_, field_path_, main__address_book_person__id, id)
   VALUES
   ('2022-04-14T00:40:41.450', '2022-04-14T00:40:41.450', '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation', UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f'), UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce'));
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), person = '{"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}'
-  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), person = '{"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}'
-  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), person = '{"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}'
+  WHERE id = UUID_TO_BIN('3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('ec983c56-320f-4d66-9dde-f180e8ac3807'), person = '{"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}'
+  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';

--- a/src/test/resources/operator/my_sql_address_book_1_set_update_commands.sql
+++ b/src/test/resources/operator/my_sql_address_book_1_set_update_commands.sql
@@ -1,60 +1,60 @@
-UPDATE test$address_book.main$address_book_root
-  SET updated_on$ = '2022-04-14T00:40:41.450', name = 'Super Heroes 2', last_updated = '2022-04-19T17:52:57.222'
-  WHERE field_path$ = '/address_book';
-UPDATE test$address_book.main$address_book_settings
-  SET updated_on$ = '2022-04-14T00:40:41.450', last_name_first = false, encrypt_hero_name = true, card_colors = '[{"value":"blue"},{"value":"red"}]'
-  WHERE field_path$ = '/address_book/settings';
-UPDATE test$address_book.main$advanced_settings
-  SET updated_on$ = '2022-04-14T00:40:41.450', background_color = 4
-  WHERE field_path$ = '/address_book/settings/advanced';
-UPDATE test$address_book.main$address_book_person
-  SET updated_on$ = '2022-04-14T00:40:41.450', self$id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), self = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}', first_name = 'Lois 2', last_name = 'Lane 2', email = '[{"value":"lois.lane.2@dailyplanet.com"}]', picture = 0x50696374757265206f66204c6f6973204c616e652032
-  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path$ = '/address_book/person';
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), person = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}', relationship = 6
-  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
-UPDATE test$address_book.crypto$password
-  SET updated_on$ = '2022-04-14T00:40:41.450', current = '{"hashed":"test-hashed-lois-2","hash_version":1}', previous = '[{"hashed":"test-hashed-password2-2","hash_version":1}]'
-  WHERE field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password';
-UPDATE test$address_book.crypto$secret
-  SET updated_on$ = '2022-04-14T00:40:41.450', main = '{"encrypted":"test-encrypted-main-secret-2","cipher_version":1}', other = '[{"encrypted":"test-encrypted-secret2-2","cipher_version":1}]'
-  WHERE field_path$ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret';
-UPDATE test$address_book.main$address_book_person
-  SET updated_on$ = '2022-04-14T00:40:41.450', first_name = 'Clark 2', last_name = 'Kent 2', hero_name = 'Superman 2', email = '[{"value":"clark.kent.2@dailyplanet.com"}]', picture = 0x50696374757265206f6620436c61726b204b656e742032
-  WHERE id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f') AND field_path$ = '/address_book/person';
-UPDATE test$address_book.main$address_book_relation
-  SET updated_on$ = '2022-04-14T00:40:41.450', person$id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), person = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}', relationship = 6
-  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
-UPDATE test$address_book.crypto$password
-  SET updated_on$ = '2022-04-14T00:40:41.450', previous = '[{"hashed":"test-hashed-superman-2","hash_version":1}]'
-  WHERE field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password';
-UPDATE test$address_book.crypto$secret
-  SET updated_on$ = '2022-04-14T00:40:41.450', other = '[{"encrypted":"test-encrypted-secret2-2","cipher_version":1}]'
-  WHERE field_path$ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret';
-UPDATE test$address_book.main$person_group
-  SET updated_on$ = '2022-04-14T00:40:41.450', name = 'Marvel 2'
-  WHERE id = UUID_TO_BIN('ad9aaea8-30fe-45ed-93ef-bd368da0c756') AND field_path$ = '/address_book/groups';
-UPDATE test$address_book.main$person_group
-  SET updated_on$ = '2022-04-14T00:40:41.450', name = 'DC 2'
-  WHERE id = UUID_TO_BIN('ca0a22e8-c300-4347-91b0-167a5f6f4f9a') AND field_path$ = '/address_book/groups';
-UPDATE test$address_book.main$person_group
-  SET updated_on$ = '2022-04-14T00:40:41.450', name = 'Superman 2'
-  WHERE id = UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups';
-UPDATE test$address_book.main$address_book_person
-  SET updated_on$ = '2022-04-14T00:40:41.450', first_name = 'Clark 3', last_name = 'Kent 3', hero_name = 'Superman 3'
-  WHERE id = UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
-UPDATE test$address_book.main$address_book_person
-  SET updated_on$ = '2022-04-14T00:40:41.450', first_name = 'Lois 3', last_name = 'Lane 3', hero_name = 'n/a'
-  WHERE id = UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7') AND field_path$ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}]', info = 'Capital of New York state 2', latitude = 42.651935, longitude = -73.75478, city_center = ST_SRID(Point(-73.75478, 42.651935), 4326)
-  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"San Francisco","state":"California","country":"United States of America"}]},{"city_info":[{"name":"Albany","state":"New York","country":"United States of America"}]}]', info = 'One of the most populous and most densely populated major city in USA 2', latitude = 40.712983, longitude = -74.007206, city_center = ST_SRID(Point(-74.007206, 40.712983), 4326)
-  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}]', info = 'The cultural and financial center of Northern California 2', latitude = 37.77938, longitude = -122.418434, city_center = ST_SRID(Point(-122.418434, 37.77938), 4326)
-  WHERE name = 'San Francisco' AND state = 'California' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
-UPDATE test$address_book.city$city_info
-  SET updated_on$ = '2022-04-14T00:40:41.450', related_city_info = '[]', self2$name = 'Princeton', self2$state = 'New Jersey', self2$country = 'United States of America', self2 = '{"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}', info = 'Home of Princeton University 2', latitude = 40.360595, longitude = -74.664442, city_center = ST_SRID(Point(-74.664442, 40.360595), 4326)
-  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path$ = '/address_book/city_info';
+UPDATE test__address_book.main__address_book_root
+  SET updated_on_ = '2022-04-14T00:40:41.450', name = 'Super Heroes 2', last_updated = '2022-04-19T17:52:57.222'
+  WHERE field_path_ = '/address_book';
+UPDATE test__address_book.main__address_book_settings
+  SET updated_on_ = '2022-04-14T00:40:41.450', last_name_first = false, encrypt_hero_name = true, card_colors = '[{"value":"blue"},{"value":"red"}]'
+  WHERE field_path_ = '/address_book/settings';
+UPDATE test__address_book.main__advanced_settings
+  SET updated_on_ = '2022-04-14T00:40:41.450', background_color = 4
+  WHERE field_path_ = '/address_book/settings/advanced';
+UPDATE test__address_book.main__address_book_person
+  SET updated_on_ = '2022-04-14T00:40:41.450', self__id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), self = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}', first_name = 'Lois 2', last_name = 'Lane 2', email = '[{"value":"lois.lane.2@dailyplanet.com"}]', picture = 0x50696374757265206f66204c6f6973204c616e652032
+  WHERE id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd') AND field_path_ = '/address_book/person';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), person = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}', relationship = 6
+  WHERE id = UUID_TO_BIN('16634916-8f83-4376-ad42-37038e108a0b') AND field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation';
+UPDATE test__address_book.crypto__password
+  SET updated_on_ = '2022-04-14T00:40:41.450', current = '{"hashed":"test-hashed-lois-2","hash_version":1}', previous = '[{"hashed":"test-hashed-password2-2","hash_version":1}]'
+  WHERE field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password';
+UPDATE test__address_book.crypto__secret
+  SET updated_on_ = '2022-04-14T00:40:41.450', main = '{"encrypted":"test-encrypted-main-secret-2","cipher_version":1}', other = '[{"encrypted":"test-encrypted-secret2-2","cipher_version":1}]'
+  WHERE field_path_ = '/address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret';
+UPDATE test__address_book.main__address_book_person
+  SET updated_on_ = '2022-04-14T00:40:41.450', first_name = 'Clark 2', last_name = 'Kent 2', hero_name = 'Superman 2', email = '[{"value":"clark.kent.2@dailyplanet.com"}]', picture = 0x50696374757265206f6620436c61726b204b656e742032
+  WHERE id = UUID_TO_BIN('cc477201-48ec-4367-83a4-7fdbd92f8a6f') AND field_path_ = '/address_book/person';
+UPDATE test__address_book.main__address_book_relation
+  SET updated_on_ = '2022-04-14T00:40:41.450', person__id = UUID_TO_BIN('a8aacf55-7810-4b43-afe5-4344f25435fd'), person = '{"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}', relationship = 6
+  WHERE id = UUID_TO_BIN('05ade278-4b44-43da-a0cc-14463854e397') AND field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation';
+UPDATE test__address_book.crypto__password
+  SET updated_on_ = '2022-04-14T00:40:41.450', previous = '[{"hashed":"test-hashed-superman-2","hash_version":1}]'
+  WHERE field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password';
+UPDATE test__address_book.crypto__secret
+  SET updated_on_ = '2022-04-14T00:40:41.450', other = '[{"encrypted":"test-encrypted-secret2-2","cipher_version":1}]'
+  WHERE field_path_ = '/address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret';
+UPDATE test__address_book.main__person_group
+  SET updated_on_ = '2022-04-14T00:40:41.450', name = 'Marvel 2'
+  WHERE id = UUID_TO_BIN('ad9aaea8-30fe-45ed-93ef-bd368da0c756') AND field_path_ = '/address_book/groups';
+UPDATE test__address_book.main__person_group
+  SET updated_on_ = '2022-04-14T00:40:41.450', name = 'DC 2'
+  WHERE id = UUID_TO_BIN('ca0a22e8-c300-4347-91b0-167a5f6f4f9a') AND field_path_ = '/address_book/groups';
+UPDATE test__address_book.main__person_group
+  SET updated_on_ = '2022-04-14T00:40:41.450', name = 'Superman 2'
+  WHERE id = UUID_TO_BIN('fe2aa774-e1fe-4680-a439-8bd1d0eb4abc') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups';
+UPDATE test__address_book.main__address_book_person
+  SET updated_on_ = '2022-04-14T00:40:41.450', first_name = 'Clark 3', last_name = 'Kent 3', hero_name = 'Superman 3'
+  WHERE id = UUID_TO_BIN('546a4982-b39a-4d01-aeb3-22d60c6963c0') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
+UPDATE test__address_book.main__address_book_person
+  SET updated_on_ = '2022-04-14T00:40:41.450', first_name = 'Lois 3', last_name = 'Lane 3', hero_name = 'n/a'
+  WHERE id = UUID_TO_BIN('e391c509-67d6-4846-bfea-0f7cd9c91bf7') AND field_path_ = '/address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}]', info = 'Capital of New York state 2', latitude = 42.651935, longitude = -73.75478, city_center = ST_SRID(Point(-73.75478, 42.651935), 4326)
+  WHERE name = 'Albany' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"San Francisco","state":"California","country":"United States of America"}]},{"city_info":[{"name":"Albany","state":"New York","country":"United States of America"}]}]', info = 'One of the most populous and most densely populated major city in USA 2', latitude = 40.712983, longitude = -74.007206, city_center = ST_SRID(Point(-74.007206, 40.712983), 4326)
+  WHERE name = 'New York City' AND state = 'New York' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[{"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}]', info = 'The cultural and financial center of Northern California 2', latitude = 37.77938, longitude = -122.418434, city_center = ST_SRID(Point(-122.418434, 37.77938), 4326)
+  WHERE name = 'San Francisco' AND state = 'California' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';
+UPDATE test__address_book.city__city_info
+  SET updated_on_ = '2022-04-14T00:40:41.450', related_city_info = '[]', self2__name = 'Princeton', self2__state = 'New Jersey', self2__country = 'United States of America', self2 = '{"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}', info = 'Home of Princeton University 2', latitude = 40.360595, longitude = -74.664442, city_center = ST_SRID(Point(-74.664442, 40.360595), 4326)
+  WHERE name = 'Princeton' AND state = 'New Jersey' AND country = 'United States of America' AND field_path_ = '/address_book/city_info';

--- a/src/test/resources/operator/my_sql_address_book_1_set_update_results.txt
+++ b/src/test/resources/operator/my_sql_address_book_1_set_update_results.txt
@@ -1,11 +1,11 @@
-+ Database test$address_book +
++ Database test__address_book +
 
-= Table city$city_info =
+= Table city__city_info =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info
 name: Albany
 state: New York
 country: United States of America
@@ -15,18 +15,18 @@ longitude: -73.75478
 city_center: Point(latitude: 42.651935, longitude: -73.75478, SRID: 4326)
 related_city_info: [{"city_info": [{"name": "Princeton", "state": "New Jersey", "country": "United States of America"}]}]
 self: null
-self$name: null
-self$state: null
-self$country: null
+self__name: null
+self__state: null
+self__country: null
 self2: null
-self2$name: null
-self2$state: null
-self2$country: null
+self2__name: null
+self2__state: null
+self2__country: null
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info
 name: New York City
 state: New York
 country: United States of America
@@ -36,18 +36,18 @@ longitude: -74.007206
 city_center: Point(latitude: 40.712983, longitude: -74.007206, SRID: 4326)
 related_city_info: [{"city_info": [{"name": "San Francisco", "state": "California", "country": "United States of America"}]}, {"city_info": [{"name": "Albany", "state": "New York", "country": "United States of America"}]}]
 self: null
-self$name: null
-self$state: null
-self$country: null
+self__name: null
+self__state: null
+self__country: null
 self2: null
-self2$name: null
-self2$state: null
-self2$country: null
+self2__name: null
+self2__state: null
+self2__country: null
 
 * Row 3 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info
 name: Princeton
 state: New Jersey
 country: United States of America
@@ -57,18 +57,18 @@ longitude: -74.664442
 city_center: Point(latitude: 40.360595, longitude: -74.664442, SRID: 4326)
 related_city_info: []
 self: {"city_info":[{"name":"Princeton","state":"New Jersey","country":"United States of America"}]}
-self$name: Princeton
-self$state: New Jersey
-self$country: United States of America
+self__name: Princeton
+self__state: New Jersey
+self__country: United States of America
 self2: {"city_info":[{"country":"United States of America","state":"New Jersey","name":"Princeton"}]}
-self2$name: Princeton
-self2$state: New Jersey
-self2$country: United States of America
+self2__name: Princeton
+self2__state: New Jersey
+self2__country: United States of America
 
 * Row 4 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info
 name: San Francisco
 state: California
 country: United States of America
@@ -78,67 +78,67 @@ longitude: -122.418434
 city_center: Point(latitude: 37.77938, longitude: -122.418434, SRID: 4326)
 related_city_info: [{"city_info": [{"name": "Princeton", "state": "New Jersey", "country": "United States of America"}]}]
 self: null
-self$name: null
-self$state: null
-self$country: null
+self__name: null
+self__state: null
+self__country: null
 self2: null
-self2$name: null
-self2$state: null
-self2$country: null
+self2__name: null
+self2__state: null
+self2__country: null
 
-= Table crypto$password =
+= Table crypto__password =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/password
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 current: null
 previous: [{"hashed": "test-hashed-superman-2", "hash_version": 1}]
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password
-main$person_group$id: null
-main$address_book_person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/password
+main__person_group__id: null
+main__address_book_person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 current: {"hashed": "test-hashed-lois-2", "hash_version": 1}
 previous: [{"hashed": "test-hashed-password2-2", "hash_version": 1}]
 
-= Table crypto$secret =
+= Table crypto__secret =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/secret
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 main: null
 other: [{"encrypted": "test-encrypted-secret2-2", "cipher_version": 1}]
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret
-main$person_group$id: null
-main$address_book_person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/secret
+main__person_group__id: null
+main__address_book_person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 main: {"encrypted": "test-encrypted-main-secret-2", "cipher_version": 1}
 other: [{"encrypted": "test-encrypted-secret2-2", "cipher_version": 1}]
 
-= Table keyless$keyed_child =
+= Table keyless__keyed_child =
 
-= Table keyless$keyless =
+= Table keyless__keyless =
 
-= Table keyless$keyless_child =
+= Table keyless__keyless_child =
 
-= Table main$address_book_person =
+= Table main__address_book_person =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
-main$person_group$id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
+main__person_group__id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
 id: 546a4982-b39a-4d01-aeb3-22d60c6963c0
 first_name: Clark 3
 last_name: Kent 3
@@ -146,13 +146,13 @@ hero_name: Superman 3
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person
+main__person_group__id: null
 id: a8aacf55-7810-4b43-afe5-4344f25435fd
 first_name: Lois 2
 last_name: Lane 2
@@ -160,13 +160,13 @@ hero_name: null
 email: [{"value": "lois.lane.2@dailyplanet.com"}]
 picture: Picture of Lois Lane 2
 self: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-self$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+self__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 
 * Row 3 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person
+main__person_group__id: null
 id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 first_name: Clark 2
 last_name: Kent 2
@@ -174,13 +174,13 @@ hero_name: Superman 2
 email: [{"value": "clark.kent.2@dailyplanet.com"}]
 picture: Picture of Clark Kent 2
 self: null
-self$id: null
+self__id: null
 
 * Row 4 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
-main$person_group$id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups[fe2aa774-e1fe-4680-a439-8bd1d0eb4abc]/persons
+main__person_group__id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
 id: e391c509-67d6-4846-bfea-0f7cd9c91bf7
 first_name: Lois 3
 last_name: Lane 3
@@ -188,13 +188,13 @@ hero_name: n/a
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
 * Row 5 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/person
-main$person_group$id: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/person
+main__person_group__id: null
 id: ec983c56-320f-4d66-9dde-f180e8ac3807
 first_name: Jimmy
 last_name: Olsen
@@ -202,95 +202,95 @@ hero_name: null
 email: null
 picture: null
 self: null
-self$id: null
+self__id: null
 
-= Table main$address_book_relation =
+= Table main__address_book_relation =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 id: 05ade278-4b44-43da-a0cc-14463854e397
 relationship: 6
 person: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation
-main$person_group$id: null
-main$address_book_person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[a8aacf55-7810-4b43-afe5-4344f25435fd]/relation
+main__person_group__id: null
+main__address_book_person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 id: 16634916-8f83-4376-ad42-37038e108a0b
 relationship: 6
 person: {"person":[{"id":"a8aacf55-7810-4b43-afe5-4344f25435fd"}]}
-person$id: a8aacf55-7810-4b43-afe5-4344f25435fd
+person__id: a8aacf55-7810-4b43-afe5-4344f25435fd
 
 * Row 3 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/relation
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
 id: 3c71ede8-8ded-4038-b6e9-dcc4a0f3a8ce
 relationship: 7
 person: {"person":[{"id":"ec983c56-320f-4d66-9dde-f180e8ac3807"}]}
-person$id: ec983c56-320f-4d66-9dde-f180e8ac3807
+person__id: ec983c56-320f-4d66-9dde-f180e8ac3807
 
-= Table main$address_book_root =
+= Table main__address_book_root =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book
-singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book
+singleton_key_: 0
 name: Super Heroes 2
 last_updated: 2022-04-19 17:52:57.222
 
-= Table main$address_book_settings =
+= Table main__address_book_settings =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/settings
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/settings
+main__address_book_root__singleton_key_: 0
 last_name_first: 0
 encrypt_hero_name: 1
 card_colors: [{"value": "blue"}, {"value": "red"}]
 
-= Table main$advanced_settings =
+= Table main__advanced_settings =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/settings/advanced
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/settings/advanced
+main__address_book_root__singleton_key_: 0
 background_color: 4
 
-= Table main$person_group =
+= Table main__person_group =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/groups
-main$person_group$id: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/groups
+main__person_group__id: null
 id: ad9aaea8-30fe-45ed-93ef-bd368da0c756
 name: Marvel 2
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/groups
-main$person_group$id: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/groups
+main__person_group__id: null
 id: ca0a22e8-c300-4347-91b0-167a5f6f4f9a
 name: DC 2
 
 * Row 3 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups
-main$person_group$id: ca0a22e8-c300-4347-91b0-167a5f6f4f9a
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/groups[ca0a22e8-c300-4347-91b0-167a5f6f4f9a]/sub_groups
+main__person_group__id: ca0a22e8-c300-4347-91b0-167a5f6f4f9a
 id: fe2aa774-e1fe-4680-a439-8bd1d0eb4abc
 name: Superman 2

--- a/src/test/resources/operator/my_sql_address_book_create_database_commands.sql
+++ b/src/test/resources/operator/my_sql_address_book_create_database_commands.sql
@@ -1,45 +1,45 @@
-CREATE DATABASE IF NOT EXISTS test$address_book;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_root (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  singleton_key$ INT UNSIGNED,
+CREATE DATABASE IF NOT EXISTS test__address_book;
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_root (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  singleton_key_ INT UNSIGNED,
   name VARCHAR(64),
   last_updated TIMESTAMP(3),
-  PRIMARY KEY (singleton_key$)
+  PRIMARY KEY (singleton_key_)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_settings (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$address_book_root$singleton_key$ INT UNSIGNED,
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_settings (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__address_book_root__singleton_key_ INT UNSIGNED,
   last_name_first BOOLEAN,
   encrypt_hero_name BOOLEAN,
   card_colors JSON,
-  UNIQUE INDEX main$address_book_root$singleton_key$ (main$address_book_root$singleton_key$)
+  UNIQUE INDEX main__address_book_root__singleton_key_ (main__address_book_root__singleton_key_)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$advanced_settings (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$address_book_root$singleton_key$ INT UNSIGNED,
+CREATE TABLE IF NOT EXISTS test__address_book.main__advanced_settings (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__address_book_root__singleton_key_ INT UNSIGNED,
   background_color INT UNSIGNED,
-  UNIQUE INDEX main$address_book_root$singleton_key$ (main$address_book_root$singleton_key$)
+  UNIQUE INDEX main__address_book_root__singleton_key_ (main__address_book_root__singleton_key_)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$person_group (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.main__person_group (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
   id BINARY(16),
   name VARCHAR(64),
   PRIMARY KEY (id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_person (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_person (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
   id BINARY(16),
   first_name VARCHAR(64),
   last_name VARCHAR(64),
@@ -47,26 +47,26 @@ CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_person (
   email JSON,
   picture BLOB,
   self TEXT,
-  self$id BINARY(16),
+  self__id BINARY(16),
   PRIMARY KEY (id),
-  UNIQUE INDEX self (self$id)
+  UNIQUE INDEX self (self__id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_relation (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_relation (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
   id BINARY(16),
   relationship INT UNSIGNED,
   person TEXT,
-  person$id BINARY(16),
+  person__id BINARY(16),
   PRIMARY KEY (id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.city$city_info (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
+CREATE TABLE IF NOT EXISTS test__address_book.city__city_info (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
   name VARCHAR(128),
   state VARCHAR(64),
   country VARCHAR(64),
@@ -76,101 +76,101 @@ CREATE TABLE IF NOT EXISTS test$address_book.city$city_info (
   city_center POINT SRID 4326,
   related_city_info JSON,
   self TEXT,
-  self$name VARCHAR(128),
-  self$state VARCHAR(64),
-  self$country VARCHAR(64),
+  self__name VARCHAR(128),
+  self__state VARCHAR(64),
+  self__country VARCHAR(64),
   self2 TEXT,
-  self2$name VARCHAR(128),
-  self2$state VARCHAR(64),
-  self2$country VARCHAR(64),
+  self2__name VARCHAR(128),
+  self2__state VARCHAR(64),
+  self2__country VARCHAR(64),
   PRIMARY KEY (name, state, country),
   UNIQUE INDEX coordinates (latitude, longitude),
-  UNIQUE INDEX self (self$name, self$state, self$country)
+  UNIQUE INDEX self (self__name, self__state, self__country)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.crypto$password (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.crypto__password (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
   current JSON,
   previous JSON,
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.crypto$secret (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.crypto__secret (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
   main JSON,
   other JSON,
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.keyless$keyless (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
-  city$city_info$name VARCHAR(128),
-  city$city_info$state VARCHAR(64),
-  city$city_info$country VARCHAR(64),
+CREATE TABLE IF NOT EXISTS test__address_book.keyless__keyless (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
+  city__city_info__name VARCHAR(128),
+  city__city_info__state VARCHAR(64),
+  city__city_info__country VARCHAR(64),
   name VARCHAR(64),
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id),
-  UNIQUE INDEX city$city_info$name (city$city_info$name, city$city_info$state, city$city_info$country)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id),
+  UNIQUE INDEX city__city_info__name (city__city_info__name, city__city_info__state, city__city_info__country)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.keyless$keyless_child (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
-  city$city_info$name VARCHAR(128),
-  city$city_info$state VARCHAR(64),
-  city$city_info$country VARCHAR(64),
+CREATE TABLE IF NOT EXISTS test__address_book.keyless__keyless_child (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
+  city__city_info__name VARCHAR(128),
+  city__city_info__state VARCHAR(64),
+  city__city_info__country VARCHAR(64),
   name VARCHAR(64),
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id),
-  UNIQUE INDEX city$city_info$name (city$city_info$name, city$city_info$state, city$city_info$country)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id),
+  UNIQUE INDEX city__city_info__name (city__city_info__name, city__city_info__state, city__city_info__country)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.keyless$keyed_child (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
-  city$city_info$name VARCHAR(128),
-  city$city_info$state VARCHAR(64),
-  city$city_info$country VARCHAR(64),
+CREATE TABLE IF NOT EXISTS test__address_book.keyless__keyed_child (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
+  city__city_info__name VARCHAR(128),
+  city__city_info__state VARCHAR(64),
+  city__city_info__country VARCHAR(64),
   name VARCHAR(64),
   other INT,
   PRIMARY KEY (name)
 ) ENGINE = InnoDB;
-ALTER TABLE test$address_book.main$address_book_settings
-  ADD FOREIGN KEY (main$address_book_root$singleton_key$) REFERENCES main$address_book_root(singleton_key$) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.main$advanced_settings
-  ADD FOREIGN KEY (main$address_book_root$singleton_key$) REFERENCES main$address_book_settings(main$address_book_root$singleton_key$) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.main$person_group
-  ADD FOREIGN KEY (main$person_group$id) REFERENCES main$person_group(id) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.main$address_book_person
-  ADD FOREIGN KEY (main$person_group$id) REFERENCES main$person_group(id) ON DELETE RESTRICT,
-  ADD FOREIGN KEY (self$id) REFERENCES main$address_book_person(id) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.main$address_book_relation
-  ADD FOREIGN KEY (main$address_book_person$id) REFERENCES main$address_book_person(id) ON DELETE RESTRICT,
-  ADD FOREIGN KEY (person$id) REFERENCES main$address_book_person(id) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.city$city_info
-  ADD FOREIGN KEY (self$name, self$state, self$country) REFERENCES city$city_info(name, state, country) ON DELETE RESTRICT,
-  ADD FOREIGN KEY (self2$name, self2$state, self2$country) REFERENCES city$city_info(name, state, country) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.crypto$password
-  ADD FOREIGN KEY (main$address_book_person$id) REFERENCES main$address_book_person(id) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.crypto$secret
-  ADD FOREIGN KEY (main$address_book_person$id) REFERENCES main$address_book_person(id) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.keyless$keyless
-  ADD FOREIGN KEY (main$address_book_person$id) REFERENCES main$address_book_person(id) ON DELETE RESTRICT,
-  ADD FOREIGN KEY (city$city_info$name, city$city_info$state, city$city_info$country) REFERENCES city$city_info(name, state, country) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.keyless$keyless_child
-  ADD FOREIGN KEY (main$address_book_person$id) REFERENCES keyless$keyless(main$address_book_person$id) ON DELETE RESTRICT,
-  ADD FOREIGN KEY (city$city_info$name, city$city_info$state, city$city_info$country) REFERENCES keyless$keyless(city$city_info$name, city$city_info$state, city$city_info$country) ON DELETE RESTRICT;
-ALTER TABLE test$address_book.keyless$keyed_child
-  ADD FOREIGN KEY (main$address_book_person$id) REFERENCES keyless$keyless(main$address_book_person$id) ON DELETE RESTRICT,
-  ADD FOREIGN KEY (city$city_info$name, city$city_info$state, city$city_info$country) REFERENCES keyless$keyless(city$city_info$name, city$city_info$state, city$city_info$country) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.main__address_book_settings
+  ADD FOREIGN KEY (main__address_book_root__singleton_key_) REFERENCES main__address_book_root(singleton_key_) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.main__advanced_settings
+  ADD FOREIGN KEY (main__address_book_root__singleton_key_) REFERENCES main__address_book_settings(main__address_book_root__singleton_key_) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.main__person_group
+  ADD FOREIGN KEY (main__person_group__id) REFERENCES main__person_group(id) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.main__address_book_person
+  ADD FOREIGN KEY (main__person_group__id) REFERENCES main__person_group(id) ON DELETE RESTRICT,
+  ADD FOREIGN KEY (self__id) REFERENCES main__address_book_person(id) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.main__address_book_relation
+  ADD FOREIGN KEY (main__address_book_person__id) REFERENCES main__address_book_person(id) ON DELETE RESTRICT,
+  ADD FOREIGN KEY (person__id) REFERENCES main__address_book_person(id) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.city__city_info
+  ADD FOREIGN KEY (self__name, self__state, self__country) REFERENCES city__city_info(name, state, country) ON DELETE RESTRICT,
+  ADD FOREIGN KEY (self2__name, self2__state, self2__country) REFERENCES city__city_info(name, state, country) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.crypto__password
+  ADD FOREIGN KEY (main__address_book_person__id) REFERENCES main__address_book_person(id) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.crypto__secret
+  ADD FOREIGN KEY (main__address_book_person__id) REFERENCES main__address_book_person(id) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.keyless__keyless
+  ADD FOREIGN KEY (main__address_book_person__id) REFERENCES main__address_book_person(id) ON DELETE RESTRICT,
+  ADD FOREIGN KEY (city__city_info__name, city__city_info__state, city__city_info__country) REFERENCES city__city_info(name, state, country) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.keyless__keyless_child
+  ADD FOREIGN KEY (main__address_book_person__id) REFERENCES keyless__keyless(main__address_book_person__id) ON DELETE RESTRICT,
+  ADD FOREIGN KEY (city__city_info__name, city__city_info__state, city__city_info__country) REFERENCES keyless__keyless(city__city_info__name, city__city_info__state, city__city_info__country) ON DELETE RESTRICT;
+ALTER TABLE test__address_book.keyless__keyed_child
+  ADD FOREIGN KEY (main__address_book_person__id) REFERENCES keyless__keyless(main__address_book_person__id) ON DELETE RESTRICT,
+  ADD FOREIGN KEY (city__city_info__name, city__city_info__state, city__city_info__country) REFERENCES keyless__keyless(city__city_info__name, city__city_info__state, city__city_info__country) ON DELETE RESTRICT;

--- a/src/test/resources/operator/my_sql_address_book_create_database_commands_no_foreign_keys.sql
+++ b/src/test/resources/operator/my_sql_address_book_create_database_commands_no_foreign_keys.sql
@@ -1,45 +1,45 @@
-CREATE DATABASE IF NOT EXISTS test$address_book;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_root (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  singleton_key$ INT UNSIGNED,
+CREATE DATABASE IF NOT EXISTS test__address_book;
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_root (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  singleton_key_ INT UNSIGNED,
   name VARCHAR(64),
   last_updated TIMESTAMP(3),
-  PRIMARY KEY (singleton_key$)
+  PRIMARY KEY (singleton_key_)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_settings (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$address_book_root$singleton_key$ INT UNSIGNED,
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_settings (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__address_book_root__singleton_key_ INT UNSIGNED,
   last_name_first BOOLEAN,
   encrypt_hero_name BOOLEAN,
   card_colors JSON,
-  UNIQUE INDEX main$address_book_root$singleton_key$ (main$address_book_root$singleton_key$)
+  UNIQUE INDEX main__address_book_root__singleton_key_ (main__address_book_root__singleton_key_)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$advanced_settings (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$address_book_root$singleton_key$ INT UNSIGNED,
+CREATE TABLE IF NOT EXISTS test__address_book.main__advanced_settings (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__address_book_root__singleton_key_ INT UNSIGNED,
   background_color INT UNSIGNED,
-  UNIQUE INDEX main$address_book_root$singleton_key$ (main$address_book_root$singleton_key$)
+  UNIQUE INDEX main__address_book_root__singleton_key_ (main__address_book_root__singleton_key_)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$person_group (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.main__person_group (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
   id BINARY(16),
   name VARCHAR(64),
   PRIMARY KEY (id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_person (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_person (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
   id BINARY(16),
   first_name VARCHAR(64),
   last_name VARCHAR(64),
@@ -47,26 +47,26 @@ CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_person (
   email JSON,
   picture BLOB,
   self TEXT,
-  self$id BINARY(16),
+  self__id BINARY(16),
   PRIMARY KEY (id),
-  UNIQUE INDEX self (self$id)
+  UNIQUE INDEX self (self__id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.main$address_book_relation (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.main__address_book_relation (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
   id BINARY(16),
   relationship INT UNSIGNED,
   person TEXT,
-  person$id BINARY(16),
+  person__id BINARY(16),
   PRIMARY KEY (id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.city$city_info (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
+CREATE TABLE IF NOT EXISTS test__address_book.city__city_info (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
   name VARCHAR(128),
   state VARCHAR(64),
   country VARCHAR(64),
@@ -76,72 +76,72 @@ CREATE TABLE IF NOT EXISTS test$address_book.city$city_info (
   city_center POINT SRID 4326,
   related_city_info JSON,
   self TEXT,
-  self$name VARCHAR(128),
-  self$state VARCHAR(64),
-  self$country VARCHAR(64),
+  self__name VARCHAR(128),
+  self__state VARCHAR(64),
+  self__country VARCHAR(64),
   self2 TEXT,
-  self2$name VARCHAR(128),
-  self2$state VARCHAR(64),
-  self2$country VARCHAR(64),
+  self2__name VARCHAR(128),
+  self2__state VARCHAR(64),
+  self2__country VARCHAR(64),
   PRIMARY KEY (name, state, country),
   UNIQUE INDEX coordinates (latitude, longitude),
-  UNIQUE INDEX self (self$name, self$state, self$country)
+  UNIQUE INDEX self (self__name, self__state, self__country)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.crypto$password (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.crypto__password (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
   current JSON,
   previous JSON,
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.crypto$secret (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
+CREATE TABLE IF NOT EXISTS test__address_book.crypto__secret (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
   main JSON,
   other JSON,
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.keyless$keyless (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
-  city$city_info$name VARCHAR(128),
-  city$city_info$state VARCHAR(64),
-  city$city_info$country VARCHAR(64),
+CREATE TABLE IF NOT EXISTS test__address_book.keyless__keyless (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
+  city__city_info__name VARCHAR(128),
+  city__city_info__state VARCHAR(64),
+  city__city_info__country VARCHAR(64),
   name VARCHAR(64),
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id),
-  UNIQUE INDEX city$city_info$name (city$city_info$name, city$city_info$state, city$city_info$country)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id),
+  UNIQUE INDEX city__city_info__name (city__city_info__name, city__city_info__state, city__city_info__country)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.keyless$keyless_child (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
-  city$city_info$name VARCHAR(128),
-  city$city_info$state VARCHAR(64),
-  city$city_info$country VARCHAR(64),
+CREATE TABLE IF NOT EXISTS test__address_book.keyless__keyless_child (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
+  city__city_info__name VARCHAR(128),
+  city__city_info__state VARCHAR(64),
+  city__city_info__country VARCHAR(64),
   name VARCHAR(64),
-  UNIQUE INDEX main$address_book_person$id (main$address_book_person$id),
-  UNIQUE INDEX city$city_info$name (city$city_info$name, city$city_info$state, city$city_info$country)
+  UNIQUE INDEX main__address_book_person__id (main__address_book_person__id),
+  UNIQUE INDEX city__city_info__name (city__city_info__name, city__city_info__state, city__city_info__country)
 ) ENGINE = InnoDB;
-CREATE TABLE IF NOT EXISTS test$address_book.keyless$keyed_child (
-  created_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-  updated_on$ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
-  field_path$ TEXT,
-  main$person_group$id BINARY(16),
-  main$address_book_person$id BINARY(16),
-  city$city_info$name VARCHAR(128),
-  city$city_info$state VARCHAR(64),
-  city$city_info$country VARCHAR(64),
+CREATE TABLE IF NOT EXISTS test__address_book.keyless__keyed_child (
+  created_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_on_ TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  field_path_ TEXT,
+  main__person_group__id BINARY(16),
+  main__address_book_person__id BINARY(16),
+  city__city_info__name VARCHAR(128),
+  city__city_info__state VARCHAR(64),
+  city__city_info__country VARCHAR(64),
   name VARCHAR(64),
   other INT,
   PRIMARY KEY (name)

--- a/src/test/resources/operator/my_sql_address_book_db_columns_schema.txt
+++ b/src/test/resources/operator/my_sql_address_book_db_columns_schema.txt
@@ -1,531 +1,531 @@
 = Table tables =
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: city_center
 COLUMN_TYPE: point
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: country
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY: PRI
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: created_on$
+TABLE_NAME: city__city_info
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: field_path$
+TABLE_NAME: city__city_info
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: info
 COLUMN_TYPE: varchar(512)
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: latitude
 COLUMN_TYPE: double
 COLUMN_KEY: MUL
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: longitude
 COLUMN_TYPE: double
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: name
 COLUMN_TYPE: varchar(128)
 COLUMN_KEY: PRI
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: related_city_info
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: self
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: self$country
-COLUMN_TYPE: varchar(64)
-COLUMN_KEY:
-
-TABLE_NAME: city$city_info
-COLUMN_NAME: self$name
-COLUMN_TYPE: varchar(128)
-COLUMN_KEY: MUL
-
-TABLE_NAME: city$city_info
-COLUMN_NAME: self$state
-COLUMN_TYPE: varchar(64)
-COLUMN_KEY:
-
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 COLUMN_NAME: self2
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: self2$country
+TABLE_NAME: city__city_info
+COLUMN_NAME: self2__country
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: self2$name
+TABLE_NAME: city__city_info
+COLUMN_NAME: self2__name
 COLUMN_TYPE: varchar(128)
 COLUMN_KEY: MUL
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: self2$state
+TABLE_NAME: city__city_info
+COLUMN_NAME: self2__state
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
+COLUMN_NAME: self__country
+COLUMN_TYPE: varchar(64)
+COLUMN_KEY:
+
+TABLE_NAME: city__city_info
+COLUMN_NAME: self__name
+COLUMN_TYPE: varchar(128)
+COLUMN_KEY: MUL
+
+TABLE_NAME: city__city_info
+COLUMN_NAME: self__state
+COLUMN_TYPE: varchar(64)
+COLUMN_KEY:
+
+TABLE_NAME: city__city_info
 COLUMN_NAME: state
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY: PRI
 
-TABLE_NAME: city$city_info
-COLUMN_NAME: updated_on$
+TABLE_NAME: city__city_info
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: crypto$password
-COLUMN_NAME: created_on$
+TABLE_NAME: crypto__password
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: crypto$password
+TABLE_NAME: crypto__password
 COLUMN_NAME: current
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: crypto$password
-COLUMN_NAME: field_path$
+TABLE_NAME: crypto__password
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: crypto$password
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: crypto__password
+COLUMN_NAME: main__address_book_person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: UNI
 
-TABLE_NAME: crypto$password
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: crypto__password
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY:
 
-TABLE_NAME: crypto$password
+TABLE_NAME: crypto__password
 COLUMN_NAME: previous
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: crypto$password
-COLUMN_NAME: updated_on$
+TABLE_NAME: crypto__password
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: crypto$secret
-COLUMN_NAME: created_on$
+TABLE_NAME: crypto__secret
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: crypto$secret
-COLUMN_NAME: field_path$
+TABLE_NAME: crypto__secret
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: crypto$secret
+TABLE_NAME: crypto__secret
 COLUMN_NAME: main
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: crypto$secret
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: crypto__secret
+COLUMN_NAME: main__address_book_person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: UNI
 
-TABLE_NAME: crypto$secret
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: crypto__secret
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY:
 
-TABLE_NAME: crypto$secret
+TABLE_NAME: crypto__secret
 COLUMN_NAME: other
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: crypto$secret
-COLUMN_NAME: updated_on$
+TABLE_NAME: crypto__secret
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: city$city_info$country
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: city__city_info__country
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: city$city_info$name
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: city__city_info__name
 COLUMN_TYPE: varchar(128)
 COLUMN_KEY: MUL
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: city$city_info$state
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: city__city_info__state
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: created_on$
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: field_path$
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: main__address_book_person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: MUL
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
+TABLE_NAME: keyless__keyed_child
 COLUMN_NAME: name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY: PRI
 
-TABLE_NAME: keyless$keyed_child
+TABLE_NAME: keyless__keyed_child
 COLUMN_NAME: other
 COLUMN_TYPE: int
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyed_child
-COLUMN_NAME: updated_on$
+TABLE_NAME: keyless__keyed_child
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: city$city_info$country
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: city__city_info__country
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: city$city_info$name
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: city__city_info__name
 COLUMN_TYPE: varchar(128)
 COLUMN_KEY: MUL
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: city$city_info$state
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: city__city_info__state
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: created_on$
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: field_path$
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: main__address_book_person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: UNI
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
+TABLE_NAME: keyless__keyless
 COLUMN_NAME: name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless
-COLUMN_NAME: updated_on$
+TABLE_NAME: keyless__keyless
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: city$city_info$country
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: city__city_info__country
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: city$city_info$name
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: city__city_info__name
 COLUMN_TYPE: varchar(128)
 COLUMN_KEY: MUL
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: city$city_info$state
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: city__city_info__state
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: created_on$
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: field_path$
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: main__address_book_person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: UNI
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
+TABLE_NAME: keyless__keyless_child
 COLUMN_NAME: name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: keyless$keyless_child
-COLUMN_NAME: updated_on$
+TABLE_NAME: keyless__keyless_child
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
-COLUMN_NAME: created_on$
+TABLE_NAME: main__address_book_person
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: email
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
-COLUMN_NAME: field_path$
+TABLE_NAME: main__address_book_person
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: first_name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: hero_name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: PRI
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: last_name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: main__address_book_person
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: MUL
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: picture
 COLUMN_TYPE: blob
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 COLUMN_NAME: self
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_person
-COLUMN_NAME: self$id
+TABLE_NAME: main__address_book_person
+COLUMN_NAME: self__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: UNI
 
-TABLE_NAME: main$address_book_person
-COLUMN_NAME: updated_on$
+TABLE_NAME: main__address_book_person
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_relation
-COLUMN_NAME: created_on$
+TABLE_NAME: main__address_book_relation
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_relation
-COLUMN_NAME: field_path$
+TABLE_NAME: main__address_book_relation
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_relation
+TABLE_NAME: main__address_book_relation
 COLUMN_NAME: id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: PRI
 
-TABLE_NAME: main$address_book_relation
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: main__address_book_relation
+COLUMN_NAME: main__address_book_person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: MUL
 
-TABLE_NAME: main$address_book_relation
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: main__address_book_relation
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_relation
+TABLE_NAME: main__address_book_relation
 COLUMN_NAME: person
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_relation
-COLUMN_NAME: person$id
+TABLE_NAME: main__address_book_relation
+COLUMN_NAME: person__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: MUL
 
-TABLE_NAME: main$address_book_relation
+TABLE_NAME: main__address_book_relation
 COLUMN_NAME: relationship
 COLUMN_TYPE: int unsigned
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_relation
-COLUMN_NAME: updated_on$
+TABLE_NAME: main__address_book_relation
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_root
-COLUMN_NAME: created_on$
+TABLE_NAME: main__address_book_root
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_root
-COLUMN_NAME: field_path$
+TABLE_NAME: main__address_book_root
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_root
+TABLE_NAME: main__address_book_root
 COLUMN_NAME: last_updated
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_root
+TABLE_NAME: main__address_book_root
 COLUMN_NAME: name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_root
-COLUMN_NAME: singleton_key$
+TABLE_NAME: main__address_book_root
+COLUMN_NAME: singleton_key_
 COLUMN_TYPE: int unsigned
 COLUMN_KEY: PRI
 
-TABLE_NAME: main$address_book_root
-COLUMN_NAME: updated_on$
+TABLE_NAME: main__address_book_root
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_settings
+TABLE_NAME: main__address_book_settings
 COLUMN_NAME: card_colors
 COLUMN_TYPE: json
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_settings
-COLUMN_NAME: created_on$
+TABLE_NAME: main__address_book_settings
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_settings
+TABLE_NAME: main__address_book_settings
 COLUMN_NAME: encrypt_hero_name
 COLUMN_TYPE: tinyint(1)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_settings
-COLUMN_NAME: field_path$
+TABLE_NAME: main__address_book_settings
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_settings
+TABLE_NAME: main__address_book_settings
 COLUMN_NAME: last_name_first
 COLUMN_TYPE: tinyint(1)
 COLUMN_KEY:
 
-TABLE_NAME: main$address_book_settings
-COLUMN_NAME: main$address_book_root$singleton_key$
+TABLE_NAME: main__address_book_settings
+COLUMN_NAME: main__address_book_root__singleton_key_
 COLUMN_TYPE: int unsigned
 COLUMN_KEY: UNI
 
-TABLE_NAME: main$address_book_settings
-COLUMN_NAME: updated_on$
+TABLE_NAME: main__address_book_settings
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$advanced_settings
+TABLE_NAME: main__advanced_settings
 COLUMN_NAME: background_color
 COLUMN_TYPE: int unsigned
 COLUMN_KEY:
 
-TABLE_NAME: main$advanced_settings
-COLUMN_NAME: created_on$
+TABLE_NAME: main__advanced_settings
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$advanced_settings
-COLUMN_NAME: field_path$
+TABLE_NAME: main__advanced_settings
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$advanced_settings
-COLUMN_NAME: main$address_book_root$singleton_key$
+TABLE_NAME: main__advanced_settings
+COLUMN_NAME: main__address_book_root__singleton_key_
 COLUMN_TYPE: int unsigned
 COLUMN_KEY: UNI
 
-TABLE_NAME: main$advanced_settings
-COLUMN_NAME: updated_on$
+TABLE_NAME: main__advanced_settings
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$person_group
-COLUMN_NAME: created_on$
+TABLE_NAME: main__person_group
+COLUMN_NAME: created_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:
 
-TABLE_NAME: main$person_group
-COLUMN_NAME: field_path$
+TABLE_NAME: main__person_group
+COLUMN_NAME: field_path_
 COLUMN_TYPE: text
 COLUMN_KEY:
 
-TABLE_NAME: main$person_group
+TABLE_NAME: main__person_group
 COLUMN_NAME: id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: PRI
 
-TABLE_NAME: main$person_group
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: main__person_group
+COLUMN_NAME: main__person_group__id
 COLUMN_TYPE: binary(16)
 COLUMN_KEY: MUL
 
-TABLE_NAME: main$person_group
+TABLE_NAME: main__person_group
 COLUMN_NAME: name
 COLUMN_TYPE: varchar(64)
 COLUMN_KEY:
 
-TABLE_NAME: main$person_group
-COLUMN_NAME: updated_on$
+TABLE_NAME: main__person_group
+COLUMN_NAME: updated_on_
 COLUMN_TYPE: timestamp(3)
 COLUMN_KEY:

--- a/src/test/resources/operator/my_sql_address_book_db_indexes_schema.txt
+++ b/src/test/resources/operator/my_sql_address_book_db_indexes_schema.txt
@@ -1,222 +1,222 @@
 = Table tables =
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: coordinates
 COLUMN_NAME: latitude
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: coordinates
 COLUMN_NAME: longitude
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: PRIMARY
 COLUMN_NAME: name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: PRIMARY
 COLUMN_NAME: state
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: PRIMARY
 COLUMN_NAME: country
 SEQ_IN_INDEX: 3
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: self
-COLUMN_NAME: self$name
+COLUMN_NAME: self__name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: self
-COLUMN_NAME: self$state
+COLUMN_NAME: self__state
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
+TABLE_NAME: city__city_info
 INDEX_NAME: self
-COLUMN_NAME: self$country
+COLUMN_NAME: self__country
 SEQ_IN_INDEX: 3
 NON_UNIQUE: 0
 
-TABLE_NAME: city$city_info
-INDEX_NAME: self2$name
-COLUMN_NAME: self2$name
+TABLE_NAME: city__city_info
+INDEX_NAME: self2__name
+COLUMN_NAME: self2__name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: city$city_info
-INDEX_NAME: self2$name
-COLUMN_NAME: self2$state
+TABLE_NAME: city__city_info
+INDEX_NAME: self2__name
+COLUMN_NAME: self2__state
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 1
 
-TABLE_NAME: city$city_info
-INDEX_NAME: self2$name
-COLUMN_NAME: self2$country
+TABLE_NAME: city__city_info
+INDEX_NAME: self2__name
+COLUMN_NAME: self2__country
 SEQ_IN_INDEX: 3
 NON_UNIQUE: 1
 
-TABLE_NAME: crypto$password
-INDEX_NAME: main$address_book_person$id
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: crypto__password
+INDEX_NAME: main__address_book_person__id
+COLUMN_NAME: main__address_book_person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: crypto$secret
-INDEX_NAME: main$address_book_person$id
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: crypto__secret
+INDEX_NAME: main__address_book_person__id
+COLUMN_NAME: main__address_book_person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyed_child
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$name
+TABLE_NAME: keyless__keyed_child
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: keyless$keyed_child
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$state
+TABLE_NAME: keyless__keyed_child
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__state
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 1
 
-TABLE_NAME: keyless$keyed_child
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$country
+TABLE_NAME: keyless__keyed_child
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__country
 SEQ_IN_INDEX: 3
 NON_UNIQUE: 1
 
-TABLE_NAME: keyless$keyed_child
-INDEX_NAME: main$address_book_person$id
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: keyless__keyed_child
+INDEX_NAME: main__address_book_person__id
+COLUMN_NAME: main__address_book_person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: keyless$keyed_child
+TABLE_NAME: keyless__keyed_child
 INDEX_NAME: PRIMARY
 COLUMN_NAME: name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$name
+TABLE_NAME: keyless__keyless
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$state
+TABLE_NAME: keyless__keyless
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__state
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$country
+TABLE_NAME: keyless__keyless
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__country
 SEQ_IN_INDEX: 3
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless
-INDEX_NAME: main$address_book_person$id
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: keyless__keyless
+INDEX_NAME: main__address_book_person__id
+COLUMN_NAME: main__address_book_person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless_child
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$name
+TABLE_NAME: keyless__keyless_child
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__name
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless_child
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$state
+TABLE_NAME: keyless__keyless_child
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__state
 SEQ_IN_INDEX: 2
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless_child
-INDEX_NAME: city$city_info$name
-COLUMN_NAME: city$city_info$country
+TABLE_NAME: keyless__keyless_child
+INDEX_NAME: city__city_info__name
+COLUMN_NAME: city__city_info__country
 SEQ_IN_INDEX: 3
 NON_UNIQUE: 0
 
-TABLE_NAME: keyless$keyless_child
-INDEX_NAME: main$address_book_person$id
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: keyless__keyless_child
+INDEX_NAME: main__address_book_person__id
+COLUMN_NAME: main__address_book_person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$address_book_person
-INDEX_NAME: main$person_group$id
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: main__address_book_person
+INDEX_NAME: main__person_group__id
+COLUMN_NAME: main__person_group__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 INDEX_NAME: PRIMARY
 COLUMN_NAME: id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$address_book_person
+TABLE_NAME: main__address_book_person
 INDEX_NAME: self
-COLUMN_NAME: self$id
+COLUMN_NAME: self__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$address_book_relation
-INDEX_NAME: main$address_book_person$id
-COLUMN_NAME: main$address_book_person$id
+TABLE_NAME: main__address_book_relation
+INDEX_NAME: main__address_book_person__id
+COLUMN_NAME: main__address_book_person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: main$address_book_relation
-INDEX_NAME: person$id
-COLUMN_NAME: person$id
+TABLE_NAME: main__address_book_relation
+INDEX_NAME: person__id
+COLUMN_NAME: person__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: main$address_book_relation
+TABLE_NAME: main__address_book_relation
 INDEX_NAME: PRIMARY
 COLUMN_NAME: id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$address_book_root
+TABLE_NAME: main__address_book_root
 INDEX_NAME: PRIMARY
-COLUMN_NAME: singleton_key$
+COLUMN_NAME: singleton_key_
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$address_book_settings
-INDEX_NAME: main$address_book_root$singleton_key$
-COLUMN_NAME: main$address_book_root$singleton_key$
+TABLE_NAME: main__address_book_settings
+INDEX_NAME: main__address_book_root__singleton_key_
+COLUMN_NAME: main__address_book_root__singleton_key_
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$advanced_settings
-INDEX_NAME: main$address_book_root$singleton_key$
-COLUMN_NAME: main$address_book_root$singleton_key$
+TABLE_NAME: main__advanced_settings
+INDEX_NAME: main__address_book_root__singleton_key_
+COLUMN_NAME: main__address_book_root__singleton_key_
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 0
 
-TABLE_NAME: main$person_group
-INDEX_NAME: main$person_group$id
-COLUMN_NAME: main$person_group$id
+TABLE_NAME: main__person_group
+INDEX_NAME: main__person_group__id
+COLUMN_NAME: main__person_group__id
 SEQ_IN_INDEX: 1
 NON_UNIQUE: 1
 
-TABLE_NAME: main$person_group
+TABLE_NAME: main__person_group
 INDEX_NAME: PRIMARY
 COLUMN_NAME: id
 SEQ_IN_INDEX: 1

--- a/src/test/resources/operator/my_sql_create_keyless_entities_results.txt
+++ b/src/test/resources/operator/my_sql_create_keyless_entities_results.txt
@@ -1,73 +1,73 @@
-= Table keyless$keyless =
+= Table keyless__keyless =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
-city$city_info$name: null
-city$city_info$state: null
-city$city_info$country: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+city__city_info__name: null
+city__city_info__state: null
+city__city_info__country: null
 name: Clark keyless
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/city_info[Fremont,California,USA]/keyless
-main$person_group$id: null
-main$address_book_person$id: null
-city$city_info$name: Fremont
-city$city_info$state: California
-city$city_info$country: USA
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/city_info[Fremont,California,USA]/keyless
+main__person_group__id: null
+main__address_book_person__id: null
+city__city_info__name: Fremont
+city__city_info__state: California
+city__city_info__country: USA
 name: Fremont keyless
 
-= Table keyless$keyless_child =
+= Table keyless__keyless_child =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyless_child
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
-city$city_info$name: null
-city$city_info$state: null
-city$city_info$country: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyless_child
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+city__city_info__name: null
+city__city_info__state: null
+city__city_info__country: null
 name: Clark keyless child
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/city_info[Fremont,California,USA]/keyless/keyless_child
-main$person_group$id: null
-main$address_book_person$id: null
-city$city_info$name: Fremont
-city$city_info$state: California
-city$city_info$country: USA
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/city_info[Fremont,California,USA]/keyless/keyless_child
+main__person_group__id: null
+main__address_book_person__id: null
+city__city_info__name: Fremont
+city__city_info__state: California
+city__city_info__country: USA
 name: Fremont keyless child
 
-= Table keyless$keyed_child =
+= Table keyless__keyed_child =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyed_child
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
-city$city_info$name: null
-city$city_info$state: null
-city$city_info$country: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyed_child
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+city__city_info__name: null
+city__city_info__state: null
+city__city_info__country: null
 name: Clark keyed child
 other: 0
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/city_info[Fremont,California,USA]/keyless/keyed_child
-main$person_group$id: null
-main$address_book_person$id: null
-city$city_info$name: Fremont
-city$city_info$state: California
-city$city_info$country: USA
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/city_info[Fremont,California,USA]/keyless/keyed_child
+main__person_group__id: null
+main__address_book_person__id: null
+city__city_info__name: Fremont
+city__city_info__state: California
+city__city_info__country: USA
 name: Fremont keyed child
 other: 1

--- a/src/test/resources/operator/my_sql_create_singleton_entities_results.txt
+++ b/src/test/resources/operator/my_sql_create_singleton_entities_results.txt
@@ -1,29 +1,29 @@
-= Table main$address_book_root =
+= Table main__address_book_root =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book
-singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book
+singleton_key_: 0
 name: Super Heroes
 last_updated: 1970-01-19 08:52:27.731
 
-= Table main$address_book_settings =
+= Table main__address_book_settings =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/settings
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/settings
+main__address_book_root__singleton_key_: 0
 last_name_first: 1
 encrypt_hero_name: 0
 card_colors: [{"value": "orange"}]
 
-= Table main$advanced_settings =
+= Table main__advanced_settings =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-03-03 00:30:31.330
-field_path$: /address_book/settings/advanced
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-03-03 00:30:31.330
+field_path_: /address_book/settings/advanced
+main__address_book_root__singleton_key_: 0
 background_color: 3

--- a/src/test/resources/operator/my_sql_update_keyless_entities_results.txt
+++ b/src/test/resources/operator/my_sql_update_keyless_entities_results.txt
@@ -1,73 +1,73 @@
-= Table keyless$keyless =
+= Table keyless__keyless =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
-city$city_info$name: null
-city$city_info$state: null
-city$city_info$country: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+city__city_info__name: null
+city__city_info__state: null
+city__city_info__country: null
 name: Clark Kent keyless
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info[Fremont,California,USA]/keyless
-main$person_group$id: null
-main$address_book_person$id: null
-city$city_info$name: Fremont
-city$city_info$state: California
-city$city_info$country: USA
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info[Fremont,California,USA]/keyless
+main__person_group__id: null
+main__address_book_person__id: null
+city__city_info__name: Fremont
+city__city_info__state: California
+city__city_info__country: USA
 name: Fremont California keyless
 
-= Table keyless$keyless_child =
+= Table keyless__keyless_child =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyless_child
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
-city$city_info$name: null
-city$city_info$state: null
-city$city_info$country: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyless_child
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+city__city_info__name: null
+city__city_info__state: null
+city__city_info__country: null
 name: Clark Kent keyless child
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info[Fremont,California,USA]/keyless/keyless_child
-main$person_group$id: null
-main$address_book_person$id: null
-city$city_info$name: Fremont
-city$city_info$state: California
-city$city_info$country: USA
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info[Fremont,California,USA]/keyless/keyless_child
+main__person_group__id: null
+main__address_book_person__id: null
+city__city_info__name: Fremont
+city__city_info__state: California
+city__city_info__country: USA
 name: Fremont California keyless child
 
-= Table keyless$keyed_child =
+= Table keyless__keyed_child =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyed_child
-main$person_group$id: null
-main$address_book_person$id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
-city$city_info$name: null
-city$city_info$state: null
-city$city_info$country: null
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/person[cc477201-48ec-4367-83a4-7fdbd92f8a6f]/keyless/keyed_child
+main__person_group__id: null
+main__address_book_person__id: cc477201-48ec-4367-83a4-7fdbd92f8a6f
+city__city_info__name: null
+city__city_info__state: null
+city__city_info__country: null
 name: Clark keyed child
 other: 1
 
 * Row 2 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/city_info[Fremont,California,USA]/keyless/keyed_child
-main$person_group$id: null
-main$address_book_person$id: null
-city$city_info$name: Fremont
-city$city_info$state: California
-city$city_info$country: USA
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/city_info[Fremont,California,USA]/keyless/keyed_child
+main__person_group__id: null
+main__address_book_person__id: null
+city__city_info__name: Fremont
+city__city_info__state: California
+city__city_info__country: USA
 name: Fremont keyed child
 other: 2

--- a/src/test/resources/operator/my_sql_update_singleton_entities_results.txt
+++ b/src/test/resources/operator/my_sql_update_singleton_entities_results.txt
@@ -1,29 +1,29 @@
-= Table main$address_book_root =
+= Table main__address_book_root =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book
-singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book
+singleton_key_: 0
 name: Super Heroes 2
 last_updated: 2022-04-30 01:07:39.123
 
-= Table main$address_book_settings =
+= Table main__address_book_settings =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/settings
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/settings
+main__address_book_root__singleton_key_: 0
 last_name_first: 0
 encrypt_hero_name: 1
 card_colors: [{"value": "red"}]
 
-= Table main$advanced_settings =
+= Table main__advanced_settings =
 
 * Row 1 *
-created_on$: 2022-03-03 00:30:31.330
-updated_on$: 2022-04-04 00:40:41.440
-field_path$: /address_book/settings/advanced
-main$address_book_root$singleton_key$: 0
+created_on_: 2022-03-03 00:30:31.330
+updated_on_: 2022-04-04 00:40:41.440
+field_path_: /address_book/settings/advanced
+main__address_book_root__singleton_key_: 0
 background_color: 4


### PR DESCRIPTION
Existing database related shell scripts could break if they don't
anticipate the existence of $ characters in database, table, and column
names. So double-underscores is a safer option for use as separators
in these names.