### PR TITLE
Use the same version for all libraries in the repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,17 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-group = "org.tree-ware.tree-ware-kotlin-mysql"
-version = "0.1.0.0"
+// The libraries are currently published to JitPack. JitPack picks up the
+// version from the repo label, resulting in all libraries from the repo
+// having the same version in JitPack. Setting the version for all projects
+// conveys this.
+allprojects {
+    group = "org.tree-ware.tree-ware-kotlin-mysql"
+    version = "0.1.0.2"
+}
 
 val mySqlConnectorVersion = "8.0.29"
 val okioVersion = "3.2.0"
-val treeWareCoreVersion = "0.1.0.1"
-val treeWareCoreTestFixturesVersion = "0.1.0.0"
+val treeWareCoreVersion = "0.1.0.2"
 
 plugins {
     kotlin("jvm") version "1.7.0"
@@ -34,7 +39,7 @@ dependencies {
     }
 
     testImplementation(project(":test-fixtures"))
-    testImplementation("org.tree-ware.tree-ware-kotlin-core:test-fixtures:$treeWareCoreTestFixturesVersion")
+    testImplementation("org.tree-ware.tree-ware-kotlin-core:test-fixtures:$treeWareCoreVersion")
     testImplementation(kotlin("test"))
 }
 

--- a/test-fixtures/build.gradle.kts
+++ b/test-fixtures/build.gradle.kts
@@ -1,8 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-group = "org.tree-ware.tree-ware-kotlin-mysql"
-version = "0.1.0.0"
-
 val hikariCpVersion = "5.0.1"
 val testContainerVersion = "1.17.2"
 val treeWareCoreVersion = "0.1.0.1"


### PR DESCRIPTION
The libraries are currently published to JitPack. JitPack picks up the version from the repo label, resulting in all libraries from the repo having the same version in JitPack. Setting the version for all projects conveys this.