### PR TITLE
Drop runtime info from aux plugins

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,29 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <DBN-PSQL>
+      <case-options enabled="true">
+        <option name="KEYWORD_CASE" value="lower" />
+        <option name="FUNCTION_CASE" value="lower" />
+        <option name="PARAMETER_CASE" value="lower" />
+        <option name="DATATYPE_CASE" value="lower" />
+        <option name="OBJECT_CASE" value="preserve" />
+      </case-options>
+      <formatting-settings enabled="false" />
+    </DBN-PSQL>
+    <DBN-SQL>
+      <case-options enabled="true">
+        <option name="KEYWORD_CASE" value="lower" />
+        <option name="FUNCTION_CASE" value="lower" />
+        <option name="PARAMETER_CASE" value="lower" />
+        <option name="DATATYPE_CASE" value="lower" />
+        <option name="OBJECT_CASE" value="preserve" />
+      </case-options>
+      <formatting-settings enabled="false">
+        <option name="STATEMENT_SPACING" value="one_line" />
+        <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
+        <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
+      </formatting-settings>
+    </DBN-SQL>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,15 +6,16 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 // conveys this.
 allprojects {
     group = "org.tree-ware.tree-ware-kotlin-mysql"
-    version = "0.5.0.0"
+    version = "0.6.0.0"
 }
 
+val log4j2Version = "2.19.0"
 val mySqlConnectorVersion = "8.0.29"
 
 plugins {
     kotlin("jvm") version "2.1.10"
     id("idea")
-    id("org.tree-ware.core") version "0.5.0.0"
+    id("org.tree-ware.core") version "0.5.2.0"
     id("java-library")
     id("maven-publish")
 }
@@ -34,6 +35,8 @@ dependencies {
 
     testImplementation(project(":test-fixtures"))
     testImplementation(libs.treeWareKotlinCoreTestFixtures)
+    testImplementation("org.apache.logging.log4j:log4j-core:${log4j2Version}")
+    testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:${log4j2Version}")
     testImplementation(kotlin("test"))
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            val treeWareKotlinCoreVersion = version("treeWareKotlinCoreVersion", "0.5.0.0")
+            val treeWareKotlinCoreVersion = version("treeWareKotlinCoreVersion", "0.5.0.1")
             library("treeWareKotlinCore", "org.tree-ware.tree-ware-kotlin-core", "core").versionRef(
                 treeWareKotlinCoreVersion
             )

--- a/src/main/kotlin/org/treeWare/mySql/aux/MySqlMetaModelMap.kt
+++ b/src/main/kotlin/org/treeWare/mySql/aux/MySqlMetaModelMap.kt
@@ -17,5 +17,8 @@ class MySqlMetaModelMap {
 }
 
 data class MySqlMetaModelMapValidated(val databaseName: String, val tableName: String) {
-    val fullName = if (tableName.isEmpty()) databaseName else "$databaseName.$tableName"
+    fun getFullName(databasePrefix: String?): String {
+        val fullName = if (tableName.isEmpty()) databaseName else "$databaseName.$tableName"
+        return if (databasePrefix == null) fullName else "${databasePrefix}__$fullName"
+    }
 }

--- a/src/main/kotlin/org/treeWare/mySql/aux/MySqlMetaModelMapAuxPlugin.kt
+++ b/src/main/kotlin/org/treeWare/mySql/aux/MySqlMetaModelMapAuxPlugin.kt
@@ -6,11 +6,11 @@ import org.treeWare.model.decoder.stateMachine.AuxDecodingStateMachineFactory
 import org.treeWare.model.encoder.AuxEncoder
 import org.treeWare.mySql.validation.validateMySqlMetaModelMap
 
-class MySqlMetaModelMapAuxPlugin(private val environment: String) : MetaModelAuxPlugin {
+class MySqlMetaModelMapAuxPlugin() : MetaModelAuxPlugin {
     override val auxName: String = MY_SQL_META_MODEL_MAP_CODEC_AUX_NAME
     override val auxDecodingStateMachineFactory: AuxDecodingStateMachineFactory = { MySqlMetaModelMapStateMachine(it) }
     override val auxEncoder: AuxEncoder = MySqlMetaModelMapEncoder()
 
     override fun validate(metaModel: MutableEntityModel): List<String> =
-        validateMySqlMetaModelMap(metaModel, environment)
+        validateMySqlMetaModelMap(metaModel)
 }

--- a/src/main/kotlin/org/treeWare/mySql/operator/CreateDatabase.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/CreateDatabase.kt
@@ -13,9 +13,17 @@ fun createDatabase(
     dataSource: DataSource,
     fullyQualifyTableNames: Boolean = true,
     logCommands: Boolean = false,
+    databasePrefix: String? = null,
     foreignKeyConstraints: CreateForeignKeyConstraints = CreateForeignKeyConstraints.ALL
 ) = dataSource.connection.use { connection ->
-    val changeSets = generateDdlChangeSets(metaModel, delegates, true, fullyQualifyTableNames, foreignKeyConstraints)
+    val changeSets = generateDdlChangeSets(
+        metaModel,
+        delegates,
+        true,
+        fullyQualifyTableNames,
+        databasePrefix,
+        foreignKeyConstraints
+    )
     changeSets.forEach { changeSet ->
         changeSet.commands.forEach { command ->
             if (logCommands) logger.info { command }

--- a/src/main/kotlin/org/treeWare/mySql/operator/Get.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/Get.kt
@@ -15,8 +15,9 @@ fun get(
     getEntityDelegates: EntityDelegateRegistry<GetEntityDelegate>?,
     dataSource: DataSource,
     responseModel: MutableEntityModel,
-    logCommands: Boolean = false
+    logCommands: Boolean = false,
+    databasePrefix: String? = null
 ): Response = dataSource.connection.use { connection ->
-    val getDelegate = MySqlGetDelegate(setEntityDelegates, getEntityDelegates, connection, logCommands)
+    val getDelegate = MySqlGetDelegate(setEntityDelegates, getEntityDelegates, connection, logCommands, databasePrefix)
     org.treeWare.model.operator.get(request, getDelegate, setEntityDelegates, getEntityDelegates, responseModel)
 }

--- a/src/main/kotlin/org/treeWare/mySql/operator/Set.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/Set.kt
@@ -13,9 +13,10 @@ fun set(
     entityDelegates: EntityDelegateRegistry<SetEntityDelegate>?,
     dataSource: DataSource,
     logCommands: Boolean = false,
+    databasePrefix: String? = null,
     clock: Clock = Clock.systemUTC()
 ): Response = dataSource.connection.use { connection ->
     val resolvedRootMeta = model.meta ?: throw IllegalStateException("No meta-model for model being set")
-    val setDelegate = MySqlSetDelegate(resolvedRootMeta, entityDelegates, connection, logCommands, clock)
+    val setDelegate = MySqlSetDelegate(resolvedRootMeta, entityDelegates, connection, logCommands, databasePrefix, clock)
     org.treeWare.model.operator.set(model, setDelegate, entityDelegates)
 }

--- a/src/main/kotlin/org/treeWare/mySql/operator/delegate/MySqlGetDelegate.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/delegate/MySqlGetDelegate.kt
@@ -36,7 +36,8 @@ class MySqlGetDelegate(
     private val setEntityDelegates: EntityDelegateRegistry<SetEntityDelegate>?,
     private val getEntityDelegates: EntityDelegateRegistry<GetEntityDelegate>?,
     private val connection: Connection,
-    private val logCommands: Boolean
+    private val logCommands: Boolean,
+    private val databasePrefix: String? = null
 ) : GetDelegate {
     override fun getRoot(
         fieldPath: String,
@@ -64,7 +65,7 @@ class MySqlGetDelegate(
     ): GetCompositionSetResult {
         if (requestKeys.isEmpty() && requestFields.isEmpty()) return GetCompositionSetResult.Entities(emptyList())
         val entityMeta = getCompositionEntityMeta(responseParentField)
-        val tableName = getEntityMetaTableFullName(entityMeta)
+        val tableName = getEntityMetaTableFullName(entityMeta, databasePrefix)
         val select = SelectCommandBuilder(tableName)
         requestKeys.forEach { requestKey ->
             val columns = getSqlColumns(null, requestKey, setEntityDelegates)
@@ -136,7 +137,7 @@ class MySqlGetDelegate(
     ): GetCompositionResult {
         if (requestFields.isEmpty()) return GetCompositionResult.Entity(responseEntity)
         val entityMeta = requireNotNull(responseEntity.meta) { "Entity meta is missing" }
-        val tableName = getEntityMetaTableFullName(entityMeta)
+        val tableName = getEntityMetaTableFullName(entityMeta, databasePrefix)
         val select = SelectCommandBuilder(tableName)
         if (ancestorKeys.isEmpty()) select.addWhereColumn(SINGLETON_SQL_COLUMN)
         else getAncestorKeyColumns(ancestorKeys[0]).forEach { select.addWhereColumn(it) }

--- a/src/main/kotlin/org/treeWare/mySql/operator/delegate/MySqlSetDelegate.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/delegate/MySqlSetDelegate.kt
@@ -36,6 +36,7 @@ internal class MySqlSetDelegate(
     private val entityDelegates: EntityDelegateRegistry<SetEntityDelegate>?,
     private val connection: Connection?,
     private val logCommands: Boolean = false,
+    private val databasePrefix: String? = null,
     private val clock: Clock = Clock.systemUTC(),
     private val issueCommands: Boolean = true
 ) : SetDelegate {
@@ -81,7 +82,7 @@ internal class MySqlSetDelegate(
         associations: List<FieldModel>,
         other: List<FieldModel>
     ): Response {
-        val tableName = getEntityTableFullName(entity)
+        val tableName = getEntityTableFullName(entity, databasePrefix)
         when (setAux) {
             SetAux.CREATE -> addCreateCommands(
                 tableName,
@@ -92,6 +93,7 @@ internal class MySqlSetDelegate(
                 associations,
                 other
             )
+
             SetAux.UPDATE -> addUpdateCommands(tableName, fieldPath, entityPath, keys, associations, other)
             SetAux.DELETE -> addDeleteCommands(tableName, fieldPath, entityPath, keys, entity)
         }

--- a/src/main/kotlin/org/treeWare/mySql/operator/liquibase/GenerateChangeLog.kt
+++ b/src/main/kotlin/org/treeWare/mySql/operator/liquibase/GenerateChangeLog.kt
@@ -16,6 +16,7 @@ fun generateChangeLog(
     entityDelegates: EntityDelegateRegistry<GenerateDdlCommandsEntityDelegate>?,
     createDatabase: Boolean,
     fullyQualifyTableNames: Boolean,
+    databasePrefix: String? = null,
     createForeignKeyConstraints: CreateForeignKeyConstraints = CreateForeignKeyConstraints.ALL
 ) {
     val directoryPath = getReleaseChangeLogDirectoryPath(metaModel, GENERATED_ROOT_DIRECTORY)
@@ -28,6 +29,7 @@ fun generateChangeLog(
             entityDelegates,
             createDatabase,
             fullyQualifyTableNames,
+            databasePrefix,
             createForeignKeyConstraints
         )
     }
@@ -39,6 +41,7 @@ fun generateChangeLog(
     entityDelegates: EntityDelegateRegistry<GenerateDdlCommandsEntityDelegate>?,
     createDatabase: Boolean,
     fullyQualifyTableNames: Boolean,
+    databasePrefix: String? = null,
     createForeignKeyConstraints: CreateForeignKeyConstraints = CreateForeignKeyConstraints.ALL
 ) {
     bufferedSink.writeUtf8("-- liquibase formatted sql\n\n")
@@ -50,6 +53,7 @@ fun generateChangeLog(
         entityDelegates,
         createDatabase,
         fullyQualifyTableNames,
+        databasePrefix,
         createForeignKeyConstraints
     )
     changeSets.forEach { it.writeTo(bufferedSink) }

--- a/src/main/kotlin/org/treeWare/mySql/util/GetTableName.kt
+++ b/src/main/kotlin/org/treeWare/mySql/util/GetTableName.kt
@@ -6,8 +6,8 @@ import org.treeWare.mySql.aux.getMySqlMetaModelMap
 fun getEntityMetaTableName(entityMeta: EntityModel): String = getMySqlMetaModelMap(entityMeta)?.validated?.tableName
     ?: throw IllegalStateException("Entity is not mapped to MySQL")
 
-fun getEntityMetaTableFullName(entityMeta: EntityModel): String =
-    getMySqlMetaModelMap(entityMeta)?.validated?.fullName
+fun getEntityMetaTableFullName(entityMeta: EntityModel, databasePrefix: String?): String =
+    getMySqlMetaModelMap(entityMeta)?.validated?.getFullName(databasePrefix)
         ?: throw IllegalStateException("Entity is not mapped to MySQL")
 
 fun getEntityTableName(entity: EntityModel): String {
@@ -15,7 +15,7 @@ fun getEntityTableName(entity: EntityModel): String {
     return getEntityMetaTableName(entityMeta)
 }
 
-fun getEntityTableFullName(entity: EntityModel): String {
+fun getEntityTableFullName(entity: EntityModel, databasePrefix: String?): String {
     val entityMeta = entity.meta ?: throw IllegalStateException("Entity does not have meta")
-    return getEntityMetaTableFullName(entityMeta)
+    return getEntityMetaTableFullName(entityMeta, databasePrefix)
 }

--- a/src/main/kotlin/org/treeWare/mySql/validation/ValidateMySqlMetaModelMap.kt
+++ b/src/main/kotlin/org/treeWare/mySql/validation/ValidateMySqlMetaModelMap.kt
@@ -12,8 +12,8 @@ import org.treeWare.mySql.aux.MySqlMetaModelMap
 import org.treeWare.mySql.aux.MySqlMetaModelMapValidated
 import org.treeWare.mySql.aux.getMySqlMetaModelMap
 
-fun validateMySqlMetaModelMap(metaModel: MutableEntityModel, environment: String): List<String> {
-    val visitor = ValidateMySqlMetaModelMapVisitor(environment)
+fun validateMySqlMetaModelMap(metaModel: MutableEntityModel): List<String> {
+    val visitor = ValidateMySqlMetaModelMapVisitor()
     mutableMetaModelForEach(metaModel, visitor)
     return visitor.errors
 }
@@ -51,7 +51,6 @@ private fun validateKey(entityId: String, keyFieldMeta: EntityModel): String? =
     }
 
 private class ValidateMySqlMetaModelMapVisitor(
-    private val environment: String
 ) : AbstractLeader1MutableMetaModelVisitor<TraversalAction>(TraversalAction.CONTINUE) {
     val errors = mutableListOf<String>()
     private var databaseName = ""
@@ -63,7 +62,7 @@ private class ValidateMySqlMetaModelMapVisitor(
     override fun visitMetaModel(leaderMeta1: MutableEntityModel): TraversalAction {
         val metaModelName = getMetaModelName(leaderMeta1)
         path.addLast(metaModelName)
-        databaseName = "${environment}__$metaModelName"
+        databaseName = metaModelName
         val nameErrors = validateDatabaseName(databaseName)
         if (nameErrors.isNotEmpty()) errors.addAll(nameErrors)
         else {

--- a/src/test/kotlin/org/treeWare/mySql/aux/MySqlMetaModelMapTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/aux/MySqlMetaModelMapTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 class MySqlMetaModelMapTests {
     @Test
     fun `MySQL meta-model JSON codec round trip must be lossless`() {
-        val mySqlMetaModelMapAuxPlugin = MySqlMetaModelMapAuxPlugin("test")
+        val mySqlMetaModelMapAuxPlugin = MySqlMetaModelMapAuxPlugin()
         MY_SQL_ADDRESS_BOOK_META_MODEL_FILES.forEach { file ->
             testRoundTrip(
                 file,

--- a/src/test/kotlin/org/treeWare/mySql/operator/CreateDatabaseTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/CreateDatabaseTests.kt
@@ -37,7 +37,7 @@ class CreateDatabaseTests {
         registerMySqlOperatorEntityDelegates(operatorEntityDelegateRegistry)
         val delegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
 
-        createDatabase(mySqlAddressBookMetaModel, delegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, delegates, testDataSource, databasePrefix = "test")
 
         val expectedColumnsSchemaAfter = readFile("operator/my_sql_address_book_db_columns_schema.txt")
         val actualColumnsSchemaAfter = getColumnsSchema(testDataSource, expectedDatabaseName)

--- a/src/test/kotlin/org/treeWare/mySql/operator/GenerateSetCommandsTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/GenerateSetCommandsTests.kt
@@ -51,6 +51,7 @@ class GenerateSetCommandsTests {
                 mySqlAddressBookRootEntityMeta,
                 entityDelegates,
                 connection,
+                databasePrefix = "test",
                 clock = clock,
                 issueCommands = false
             )
@@ -76,6 +77,7 @@ class GenerateSetCommandsTests {
                 mySqlAddressBookRootEntityMeta,
                 entityDelegates,
                 connection,
+                databasePrefix = "test",
                 clock = clock,
                 issueCommands = false
             )
@@ -101,6 +103,7 @@ class GenerateSetCommandsTests {
                 mySqlAddressBookRootEntityMeta,
                 entityDelegates,
                 connection,
+                databasePrefix = "test",
                 clock = clock,
                 issueCommands = false
             )
@@ -126,6 +129,7 @@ class GenerateSetCommandsTests {
                 mySqlAddressBookRootEntityMeta,
                 entityDelegates,
                 connection,
+                databasePrefix = "test",
                 clock = clock,
                 issueCommands = false
             )

--- a/src/test/kotlin/org/treeWare/mySql/operator/GetTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/GetTests.kt
@@ -37,7 +37,7 @@ class GetTests {
         getEntityDelegates = operatorEntityDelegateRegistry.get(GetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
     }
 
     @BeforeEach
@@ -51,7 +51,7 @@ class GetTests {
         val now = "2022-04-14T00:40:41.450Z"
         val clock = Clock.fixed(Instant.parse(now), ZoneOffset.UTC)
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, true, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, true, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
     }
 
@@ -69,7 +69,7 @@ class GetTests {
             entity = request
         )
         val responseModel = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
-        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel)
+        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel, databasePrefix = "test")
         assertTrue(response is Response.Success)
         assertMatchesJson(
             responseModel,
@@ -86,7 +86,7 @@ class GetTests {
             entity = request
         )
         val responseModel = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
-        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel)
+        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel, databasePrefix = "test")
         assertTrue(response is Response.Success)
         assertMatchesJson(
             responseModel,
@@ -100,7 +100,7 @@ class GetTests {
         val request = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
         decodeJsonFileIntoEntity("model/my_sql_get_request_no_parent_fields.json", entity = request)
         val responseModel = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
-        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel)
+        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel, databasePrefix = "test")
         assertTrue(response is Response.Success)
         assertMatchesJson(responseModel, "model/my_sql_get_response_no_parent_fields.json", EncodePasswords.ALL)
     }
@@ -110,7 +110,7 @@ class GetTests {
         val request = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
         decodeJsonFileIntoEntity("model/my_sql_get_request_subset_of_keys.json", entity = request)
         val responseModel = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
-        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel)
+        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel, databasePrefix = "test")
         assertTrue(response is Response.Success)
         assertMatchesJson(responseModel, "model/my_sql_get_response_subset_of_keys.json", EncodePasswords.ALL)
     }
@@ -120,7 +120,7 @@ class GetTests {
         val request = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
         decodeJsonFileIntoEntity( "model/my_sql_get_request_invalid_entity_paths.json", entity = request)
         val responseModel = MutableEntityModel(mySqlAddressBookRootEntityMeta, null)
-        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel)
+        val response = get(request, setEntityDelegates, getEntityDelegates, testDataSource, responseModel, databasePrefix = "test")
         assertTrue(response is Response.Success)
         assertMatchesJson(responseModel, "model/my_sql_get_response_invalid_entity_paths.json", EncodePasswords.ALL)
     }

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetCreateTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetCreateTests.kt
@@ -44,7 +44,7 @@ class SetCreateTests {
         setEntityDelegates = operatorEntityDelegateRegistry.get(SetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
     }
 
     @AfterEach
@@ -61,7 +61,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = readFile("operator/my_sql_address_book_1_set_create_results.txt")
         val actualRows = getDatabaseRows(testDataSource, TEST_DATABASE)
@@ -77,7 +77,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = readFile("operator/forward_referencing_association_set_create_results.txt")
         val actualRows = getDatabaseRows(testDataSource, TEST_DATABASE)
@@ -123,7 +123,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
             |= Table city__city_info =
@@ -168,7 +168,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
             |= Table main__address_book_root =
@@ -203,7 +203,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
             |= Table main__address_book_root =
@@ -248,7 +248,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
             |= Table main__address_book_root =
@@ -296,7 +296,7 @@ class SetCreateTests {
             entity = create
         )
         val expectedResponse = Response.Success
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val expectedRows = """
             |= Table main__address_book_person =
@@ -332,13 +332,13 @@ class SetCreateTests {
 
         // Create the model the first time.
         val expectedResponse1 = Response.Success
-        val actualResponse1 = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse1 = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse1, actualResponse1)
         val actualRows1 = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(expectedRows, actualRows1)
 
         // Try to create the same model again. It should fail.
-        val actualResponse2 = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse2 = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         val expectedResponse2 = Response.ErrorList(
             ErrorCode.CLIENT_ERROR,
             listOf(
@@ -464,7 +464,7 @@ class SetCreateTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = create
         )
-        val actualResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse, actualResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterCreateRows)
@@ -498,7 +498,7 @@ class SetCreateTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = create1
         )
-        val actualResponse1 = set(create1, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse1 = set(create1, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse1, actualResponse1)
         val afterCreate1Rows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreate1Rows)
@@ -537,7 +537,7 @@ class SetCreateTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = create2
         )
-        val actualResponse2 = set(create2, setEntityDelegates, testDataSource, clock = clock)
+        val actualResponse2 = set(create2, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedResponse2, actualResponse2)
         val afterCreate2Rows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreate1Rows, afterCreate2Rows)

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetDeleteTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetDeleteTests.kt
@@ -45,7 +45,7 @@ class SetDeleteTests {
         setEntityDelegates = operatorEntityDelegateRegistry.get(SetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
         emptyDatabaseRows = getDatabaseRows(testDataSource, TEST_DATABASE)
     }
 
@@ -70,7 +70,7 @@ class SetDeleteTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val expectedRows = readFile("operator/my_sql_address_book_1_set_create_results.txt")
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
@@ -93,7 +93,7 @@ class SetDeleteTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = delete
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
 
         // 3) the deletion attempt should fail and nothing should be deleted from the database.
         val expectedDeleteResponse = Response.ErrorList(
@@ -156,7 +156,7 @@ class SetDeleteTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -178,7 +178,7 @@ class SetDeleteTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = delete
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
 
         // 3) the deletion attempt should fail and nothing should be deleted from the database.
         val expectedDeleteResponse = Response.ErrorList(
@@ -210,7 +210,7 @@ class SetDeleteTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val expectedRows = readFile("operator/my_sql_address_book_1_set_create_results.txt")
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
@@ -223,7 +223,7 @@ class SetDeleteTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = delete
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
 
         // 3) since set() issues delete commands in reverse order, it should delete the entire model bottoms-up.
         val expectedDeleteResponse = Response.Success
@@ -273,7 +273,7 @@ class SetDeleteTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -306,7 +306,7 @@ class SetDeleteTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = delete
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         val expectedDeleteResponse = Response.Success
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterDeleteRows = getDatabaseRows(testDataSource, TEST_DATABASE)
@@ -354,7 +354,7 @@ class SetDeleteTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -387,7 +387,7 @@ class SetDeleteTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = delete
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         val expectedDeleteResponse = Response.Success
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterDeleteRows = getDatabaseRows(testDataSource, TEST_DATABASE)
@@ -403,7 +403,7 @@ class SetDeleteTests {
             entity = delete
         )
         val expectedDeleteResponse = Response.Success
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
     }
 
@@ -435,7 +435,7 @@ class SetDeleteTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = clock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -465,7 +465,7 @@ class SetDeleteTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = delete
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = clock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = clock)
         // NOTE: delete operations never return errors, not even when the entity to be deleted is not found.
         // While no error is returned, the delete operation should fail by not updating the database.
         val expectedDeleteResponse = Response.Success

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetKeylessEntityTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetKeylessEntityTests.kt
@@ -50,7 +50,7 @@ class SetKeylessEntityTests {
         setEntityDelegates = operatorEntityDelegateRegistry.get(SetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
         emptyDatabaseRows = getDatabaseRows(testDataSource, TEST_DATABASE)
     }
 
@@ -78,7 +78,7 @@ class SetKeylessEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = readFile("operator/my_sql_create_keyless_entities_results.txt")
         val afterCreateRows = getKeylessTableRows()
@@ -94,7 +94,7 @@ class SetKeylessEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -133,7 +133,7 @@ class SetKeylessEntityTests {
                 ),
             )
         )
-        val actualRecreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualRecreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedRecreateResponse, actualRecreateResponse)
         val afterRecreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreateRows, afterRecreateRows)
@@ -148,7 +148,7 @@ class SetKeylessEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = readFile("operator/my_sql_create_keyless_entities_results.txt")
         val afterCreateRows = getKeylessTableRows()
@@ -161,7 +161,7 @@ class SetKeylessEntityTests {
             entity = update
         )
         val expectedUpdateResponse = Response.Success
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val afterUpdateRowsExpected = readFile("operator/my_sql_update_keyless_entities_results.txt")
         val afterUpdateRows = getKeylessTableRows()
@@ -205,7 +205,7 @@ class SetKeylessEntityTests {
                 ),
             )
         )
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterUpdateRows)
@@ -220,7 +220,7 @@ class SetKeylessEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -232,7 +232,7 @@ class SetKeylessEntityTests {
             entity = delete
         )
         val expectedDeleteResponse = Response.Success
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterUpdateRows)
@@ -247,7 +247,7 @@ class SetKeylessEntityTests {
             entity = delete
         )
         val expectedDeleteResponse = Response.Success
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterUpdateRows)
@@ -290,7 +290,7 @@ class SetKeylessEntityTests {
                 ),
             )
         )
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterCreateRows)
@@ -305,7 +305,7 @@ class SetKeylessEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -351,7 +351,7 @@ class SetKeylessEntityTests {
                 ),
             )
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterDeleteRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreateRows, afterDeleteRows)

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetMixedTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetMixedTests.kt
@@ -47,7 +47,7 @@ class SetMixedTests {
         setEntityDelegates = operatorEntityDelegateRegistry.get(SetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
         emptyDatabaseRows = getDatabaseRows(testDataSource, TEST_DATABASE)
     }
 
@@ -97,7 +97,7 @@ class SetMixedTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = """
             |= Table main__address_book_person =
@@ -183,7 +183,7 @@ class SetMixedTests {
             entity = mixed
         )
         val expectedMixedResponse = Response.Success
-        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRowsExpected = """
             |= Table main__address_book_person =
@@ -294,7 +294,7 @@ class SetMixedTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = """
             |= Table main__address_book_person =
@@ -400,7 +400,7 @@ class SetMixedTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = mixed
         )
-        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRows =
             getTableRows(testDataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
@@ -434,7 +434,7 @@ class SetMixedTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = create
         )
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = """
             |= Table main__address_book_person =
@@ -516,7 +516,7 @@ class SetMixedTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = mixed
         )
-        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRows =
             getTableRows(testDataSource, TEST_DATABASE, "main__address_book_person", "main__address_book_relation")
@@ -576,7 +576,7 @@ class SetMixedTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -643,7 +643,7 @@ class SetMixedTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = mixed
         )
-        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualMixedResponse = set(mixed, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedMixedResponse, actualMixedResponse)
         val afterMixedRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreateRows, afterMixedRows)

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetSingletonEntityTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetSingletonEntityTests.kt
@@ -50,7 +50,7 @@ class SetSingletonEntityTests {
         setEntityDelegates = operatorEntityDelegateRegistry.get(SetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
         emptyDatabaseRows = getDatabaseRows(testDataSource, TEST_DATABASE)
     }
 
@@ -78,7 +78,7 @@ class SetSingletonEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = readFile("operator/my_sql_create_singleton_entities_results.txt")
         val afterCreateRows = getSingletonTableRows()
@@ -94,7 +94,7 @@ class SetSingletonEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -107,7 +107,7 @@ class SetSingletonEntityTests {
                 ElementModelError("/settings/advanced", "unable to create: duplicate"),
             )
         )
-        val actualRecreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualRecreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedRecreateResponse, actualRecreateResponse)
         val afterRecreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreateRows, afterRecreateRows)
@@ -122,7 +122,7 @@ class SetSingletonEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRowsExpected = readFile("operator/my_sql_create_singleton_entities_results.txt")
         val afterCreateRows = getSingletonTableRows()
@@ -135,7 +135,7 @@ class SetSingletonEntityTests {
             entity = update
         )
         val expectedUpdateResponse = Response.Success
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val afterUpdateRowsExpected = readFile("operator/my_sql_update_singleton_entities_results.txt")
         val afterUpdateRows = getSingletonTableRows()
@@ -158,7 +158,7 @@ class SetSingletonEntityTests {
                 ElementModelError("/settings/advanced", "unable to update"),
             )
         )
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterUpdateRows)
@@ -173,7 +173,7 @@ class SetSingletonEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -185,7 +185,7 @@ class SetSingletonEntityTests {
             entity = delete
         )
         val expectedDeleteResponse = Response.Success
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterUpdateRows)
@@ -200,7 +200,7 @@ class SetSingletonEntityTests {
             entity = delete
         )
         val expectedDeleteResponse = Response.Success
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterUpdateRows)
@@ -221,7 +221,7 @@ class SetSingletonEntityTests {
                 ElementModelError("/settings/advanced", "unable to create: no parent or target entity"),
             )
         )
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, afterCreateRows)
@@ -236,7 +236,7 @@ class SetSingletonEntityTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -261,7 +261,7 @@ class SetSingletonEntityTests {
                 )
             )
         )
-        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualDeleteResponse = set(delete, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedDeleteResponse, actualDeleteResponse)
         val afterDeleteRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreateRows, afterDeleteRows)
@@ -282,7 +282,7 @@ class SetSingletonEntityTests {
             entity = createRoot
         )
         val expectedCreateRootResponse = Response.Success
-        val actualCreateRootResponse = set(createRoot, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateRootResponse = set(createRoot, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateRootResponse, actualCreateRootResponse)
         val afterCreateRootRowsExpected = """
             |= Table main__address_book_root =
@@ -322,7 +322,7 @@ class SetSingletonEntityTests {
             entity = createChildren
         )
         val expectedCreateChildrenResponse = Response.Success
-        val actualCreateChildrenResponse = set(createChildren, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualCreateChildrenResponse = set(createChildren, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedCreateChildrenResponse, actualCreateChildrenResponse)
         val afterCreateChildrenRowsExpected = """
             |= Table main__address_book_root =

--- a/src/test/kotlin/org/treeWare/mySql/operator/SetUpdateTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/SetUpdateTests.kt
@@ -47,7 +47,7 @@ class SetUpdateTests {
         setEntityDelegates = operatorEntityDelegateRegistry.get(SetOperatorId)
 
         val createDbEntityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
-        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource)
+        createDatabase(mySqlAddressBookMetaModel, createDbEntityDelegates, testDataSource, databasePrefix = "test")
     }
 
     @AfterEach
@@ -128,7 +128,7 @@ class SetUpdateTests {
                 ),
             )
         )
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val actualRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(emptyDatabaseRows, actualRows)
@@ -149,7 +149,7 @@ class SetUpdateTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val createdRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(expectedRows, createdRows)
@@ -161,7 +161,7 @@ class SetUpdateTests {
             entity = update
         )
         val expectedUpdateResponse = Response.Success
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val updatedRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(expectedRows, updatedRows)
@@ -195,7 +195,7 @@ class SetUpdateTests {
             entity = create
         )
         val expectedCreateResponse = Response.Success
-        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, clock = createClock)
+        val actualCreateResponse = set(create, setEntityDelegates, testDataSource, databasePrefix = "test", clock = createClock)
         assertSetResponse(expectedCreateResponse, actualCreateResponse)
         val afterCreateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertNotEquals(emptyDatabaseRows, afterCreateRows)
@@ -234,7 +234,7 @@ class SetUpdateTests {
             multiAuxDecodingStateMachineFactory = auxDecodingFactory,
             entity = update
         )
-        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, clock = updateClock)
+        val actualUpdateResponse = set(update, setEntityDelegates, testDataSource, databasePrefix = "test", clock = updateClock)
         assertSetResponse(expectedUpdateResponse, actualUpdateResponse)
         val afterUpdateRows = getDatabaseRows(testDataSource, TEST_DATABASE)
         assertEquals(afterCreateRows, afterUpdateRows)

--- a/src/test/kotlin/org/treeWare/mySql/operator/liquibase/GenerateChangeLogTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/operator/liquibase/GenerateChangeLogTests.kt
@@ -18,7 +18,7 @@ class GenerateChangeLogTests {
         val entityDelegates = operatorEntityDelegateRegistry.get(GenerateDdlCommandsOperatorId)
 
         val buffer = Buffer()
-        generateChangeLog(buffer, mySqlAddressBookMetaModel, entityDelegates, true, false)
+        generateChangeLog(buffer, mySqlAddressBookMetaModel, entityDelegates, true, false, "test")
 
         val expected = readFile("operator/liquibase/my_sql_address_book_ddl_changelog.sql")
         val actual = buffer.readUtf8()
@@ -38,6 +38,7 @@ class GenerateChangeLogTests {
             entityDelegates,
             true,
             true,
+            "test",
             CreateForeignKeyConstraints.NONE
         )
 

--- a/src/test/kotlin/org/treeWare/mySql/validation/FieldValidationTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/validation/FieldValidationTests.kt
@@ -8,7 +8,7 @@ import org.treeWare.mySql.aux.MySqlMetaModelMapAuxPlugin
 import kotlin.test.Test
 
 class FieldValidationTests {
-    private val mySqlMetaModelMapAuxPlugin = MySqlMetaModelMapAuxPlugin("test")
+    private val mySqlMetaModelMapAuxPlugin = MySqlMetaModelMapAuxPlugin()
 
     @Test
     fun `Validation must fail if string fields do not specify max_size constraint`() {

--- a/src/test/kotlin/org/treeWare/mySql/validation/KeyValidationTests.kt
+++ b/src/test/kotlin/org/treeWare/mySql/validation/KeyValidationTests.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 private const val FIELD_ID = "Package 1 entity 0 field 0"
 
 class KeyValidationTests {
-    private val mySqlMetaModelMapAuxPlugin = MySqlMetaModelMapAuxPlugin("test")
+    private val mySqlMetaModelMapAuxPlugin = MySqlMetaModelMapAuxPlugin()
 
     @Test
     fun `Entities may have more than 1 key`() {

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Stdout" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601}{UTC}Z [%t] %-5level %logger{36} - %msg%n"/>
+            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+        </Console>
+        <Console name="Stderr" target="SYSTEM_ERR">
+            <PatternLayout pattern="%d{ISO8601}{UTC}Z [%t] %-5level %logger{36} - %msg%n"/>
+            <ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Stdout"/>
+            <AppenderRef ref="Stderr"/>
+        </Root>
+        <Logger name="org.treeWare" level="DEBUG" additivity="false">
+            <AppenderRef ref="Stdout"/>
+            <AppenderRef ref="Stderr"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/test-fixtures/build.gradle.kts
+++ b/test-fixtures/build.gradle.kts
@@ -6,7 +6,7 @@ val testContainerVersion = "1.17.2"
 plugins {
     kotlin("jvm") version "2.1.10"
     id("idea")
-    id("org.tree-ware.core") version "0.5.0.0"
+    id("org.tree-ware.core") version "0.5.2.0"
     id("java-library")
     id("maven-publish")
 }

--- a/test-fixtures/src/main/kotlin/org/treeWare/mySql/test/metaModel/MySqlAddressBookMetaModel.kt
+++ b/test-fixtures/src/main/kotlin/org/treeWare/mySql/test/metaModel/MySqlAddressBookMetaModel.kt
@@ -18,18 +18,18 @@ val MY_SQL_ADDRESS_BOOK_META_MODEL_FILES = listOf(
     "tree_ware/meta_model/geo.json"
 )
 
-fun newMySqlAddressBookMetaModel(environment: String, hasher: Hasher?, cipher: Cipher?): ValidatedMetaModel =
+fun newMySqlAddressBookMetaModel(hasher: Hasher?, cipher: Cipher?): ValidatedMetaModel =
     newMetaModelFromJsonFiles(
         MY_SQL_ADDRESS_BOOK_META_MODEL_FILES,
         false,
         hasher,
         cipher,
         ::mySqlAddressBookRootEntityFactory,
-        listOf(MySqlMetaModelMapAuxPlugin(environment)),
+        listOf(MySqlMetaModelMapAuxPlugin()),
         true
     )
 
-val mySqlAddressBookMetaModel = newMySqlAddressBookMetaModel("test", null, null).metaModel
+val mySqlAddressBookMetaModel = newMySqlAddressBookMetaModel(null, null).metaModel
     ?: throw IllegalStateException("Meta-model has validation errors")
 
 val mySqlAddressBookRootEntityMeta = getResolvedRootMeta(mySqlAddressBookMetaModel)


### PR DESCRIPTION
Aux plugin classes need to be specified in tree-ware configuration in `build.gradle.kts` so that they can be included in the code generated by the core tree-ware Gradle plugin. It is hard for the generated code to refer to runtime information. So the `environment` parameter has been dropped from `MySqlMetaModelMapAuxPlugin`. But the environment name is still needed in case it needs to be used as a prefix for the database name. So a `databasePrefix` parameter has been added to all the places that deal with the database name.